### PR TITLE
Shapes.txt is optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Read GTFS (public transit timetables) files"
 name = "gtfs-structures"
-version = "0.8.5"
+version = "0.8.6"
 authors = ["Tristram Gräbener <tristramg@gmail.com>"]
 repository = "https://github.com/rust-transit/gtfs-structure"
 license = "MIT"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -432,7 +432,7 @@ impl Gtfs {
         let routes_file = File::open(p.join("routes.txt"))?;
         let stop_times_file = File::open(p.join("stop_times.txt"))?;
         let agencies_file = File::open(p.join("agency.txt"))?;
-        let shapes_file = File::open(p.join("shapes.txt"))?;
+        let shapes_file = File::open(p.join("shapes.txt")).ok();
 
         let mut gtfs = Gtfs::default();
 
@@ -443,7 +443,9 @@ impl Gtfs {
         gtfs.read_routes(routes_file)?;
         gtfs.read_stop_times(stop_times_file)?;
         gtfs.read_agencies(agencies_file)?;
-        gtfs.read_shapes(shapes_file)?;
+        if let Some(s_file) = shapes_file {
+            gtfs.read_shapes(s_file)?;
+        }
 
         gtfs.read_duration = Utc::now().signed_duration_since(now).num_milliseconds();
         Ok(gtfs)


### PR DESCRIPTION
Fixed a mistake of mine, I forgot the shapes file is optional and not mandatory.
Bumped to 0.8.6.