### PR TITLE
deserialize_bool is more precise

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Read GTFS (public transit timetables) files"
 name = "gtfs-structures"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Tristram Gräbener <tristramg@gmail.com>"]
 repository = "https://github.com/rust-transit/gtfs-structure"
 license = "MIT"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -850,7 +850,11 @@ where
     D: Deserializer<'de>,
 {
     let s = String::deserialize(deserializer)?;
-    Ok(s == "1")
+    match &*s {
+            "0" => Ok(false),
+            "1" => Ok(true),
+            &_ => Err(serde::de::Error::custom(format!("Invalid value `{}`, expected 0 or 1", s))),
+        }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
We now have a better error message when a field that is supposed to be a bool is missing or has an invalid value (such as weekdays fields in calendar.txt).
Bumped to v 0.9.1