### PR TITLE
add a step in the gtfs creation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Read GTFS (public transit timetables) files"
 name = "gtfs-structures"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["Tristram Gräbener <tristramg@gmail.com>"]
 repository = "https://github.com/rust-transit/gtfs-structure"
 license = "MIT"


### PR DESCRIPTION
Instead a directly creating a `GTFS`, we now create a `RawGTFS` with
structure directly mapped on the CSV.

This will makes it possible in https://github.com/etalab/transport-validator/ to validate the raw structures and for example detect duplicates

Note: I'm still benchmarking this on a big dataset to see the impact
edit: It seems to be a bit slower, Netherlands dataset loads in 3m30 on my laptop, compared to 3m. I think it's acceptable though.
