### PR TITLE
make ObjectType hashable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Read GTFS (public transit timetables) files"
 name = "gtfs-structures"
-version = "0.10.2"
+version = "0.10.3"
 authors = ["Tristram Gräbener <tristramg@gmail.com>"]
 repository = "https://github.com/rust-transit/gtfs-structure"
 license = "MIT"

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -12,7 +12,7 @@ pub trait Type {
     fn object_type(&self) -> ObjectType;
 }
 
-#[derive(Debug, Serialize, Eq, PartialEq)]
+#[derive(Debug, Serialize, Eq, PartialEq, Hash)]
 pub enum ObjectType {
     Agency,
     Stop,


### PR DESCRIPTION
makes it possible to have `HashMap<ObjectType, _>`

Needed by the validator