### PR TITLE
Add some context to the serde error messages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Read GTFS (public transit timetables) files"
 name = "gtfs-structures"
-version = "0.11.1"
+version = "0.11.2"
 authors = ["Tristram Gräbener <tristramg@gmail.com>"]
 repository = "https://github.com/rust-transit/gtfs-structure"
 license = "MIT"


### PR DESCRIPTION
This will makes it possible to have error like:

`error while reading stops.txt: CSV deserialize error: record 12 (line:
13, byte: 739): invalid float literal`

instead of `CSV deserialize error: record 12 (line: 13, byte: 739):
invalid float literal`