### PR TITLE
use flexible reader

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Read GTFS (public transit timetables) files"
 name = "gtfs-structures"
-version = "0.11.2"
+version = "0.11.3"
 authors = ["Tristram Gräbener <tristramg@gmail.com>"]
 repository = "https://github.com/rust-transit/gtfs-structure"
 license = "MIT"


### PR DESCRIPTION
to parse files where nb of headers is different from number of columns.

we are still unable to read the [google gtfs example](https://developers.google.com/transit/gtfs/examples/gtfs-feed) since it contains a variable number of columns :cry: 