### PR TITLE
Trim the time string prior to splitting.

### DIFF
--- a/src/objects.rs
+++ b/src/objects.rs
@@ -551,7 +551,7 @@ where
 }
 
 pub fn parse_time(s: &str) -> Result<u32, Error> {
-    let v: Vec<&str> = s.split(':').collect();
+    let v: Vec<&str> = s.trim_start().split(':').collect();
     Ok(&v[0].parse()? * 3600u32 + &v[1].parse()? * 60u32 + &v[2].parse()?)
 }
 


### PR DESCRIPTION
I encountered two schedules published for Albuquerque wherein the arrival and departure times weren't zero-padded. The existing code expects something like `01:00:00` and the transit feeds published
`1:00:00` (leading space instead of `0`). The patch simply trims the string prior to splitting.