### PR TITLE
Remove failure and update reqwest/futures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Read GTFS (public transit timetables) files"
 name = "gtfs-structures"
-version = "0.16.1"
+version = "0.17.0"
 authors = ["Tristram Gräbener <tristramg@gmail.com>"]
 repository = "https://github.com/rust-transit/gtfs-structure"
 license = "MIT"
@@ -19,8 +19,7 @@ serde = "1.0"
 serde_derive = "1.0"
 chrono = "0.4"
 itertools = "0.8"
-failure = "0.1"
-failure_derive = "0.1"
+anyhow = "1"
 futures = "0.1"
 sha2 = "0.8"
 zip = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 
 [features]
 default = ["read-url"]
-read-url = ["reqwest"]
+read-url = ["reqwest", "futures"]
 
 [dependencies]
 bytes = "0.4"
@@ -20,8 +20,8 @@ serde_derive = "1.0"
 chrono = "0.4"
 itertools = "0.8"
 anyhow = "1"
-futures = "0.1"
 sha2 = "0.8"
 zip = "0.5"
 
-reqwest = { version = "0.9", optional = true }
+futures = { version = "0.3", optional = true }
+reqwest = { version = "0.10", optional = true, features = ["blocking"] }

--- a/src/gtfs.rs
+++ b/src/gtfs.rs
@@ -1,7 +1,7 @@
 use crate::{objects::*, RawGtfs};
+use anyhow::Error;
 use chrono::prelude::NaiveDate;
 use chrono::Duration;
-use failure::Error;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,6 @@
 #[macro_use]
 extern crate derivative;
 #[macro_use]
-extern crate failure_derive;
-#[macro_use]
 extern crate serde_derive;
 
 mod gtfs;

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -1,5 +1,5 @@
+use anyhow::Error;
 use chrono::{Datelike, NaiveDate, Weekday};
-use failure::Error;
 use serde::de::{self, Deserialize, Deserializer};
 use std::fmt;
 use std::sync::Arc;
@@ -23,10 +23,17 @@ pub enum ObjectType {
     Fare,
 }
 
-#[derive(Fail, Debug)]
-#[fail(display = "The id {} is not known", id)]
+#[derive(Debug)]
 pub struct ReferenceError {
     pub id: String,
+}
+
+impl std::error::Error for ReferenceError {}
+
+impl fmt::Display for ReferenceError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "The id {} is not known", self.id)
+    }
 }
 
 #[derive(Debug, Copy, Clone, PartialEq)]
@@ -563,7 +570,7 @@ where
 
     match s {
         None => Ok(None),
-        Some(t) => Ok(Some(parse_time(&t).map_err(de::Error::custom)?))
+        Some(t) => Ok(Some(parse_time(&t).map_err(de::Error::custom)?)),
     }
 }
 

--- a/src/raw_gtfs.rs
+++ b/src/raw_gtfs.rs
@@ -1,8 +1,6 @@
 use crate::objects::*;
+use anyhow::{anyhow, Context, Error};
 use chrono::Utc;
-use failure::format_err;
-use failure::Error;
-use failure::ResultExt;
 use serde::Deserialize;
 use sha2::digest::Digest;
 use sha2::Sha256;
@@ -60,7 +58,7 @@ where
         .unwrap_or_else(|| "invalid_file_name")
         .to_string();
     File::open(path)
-        .map_err(|e| format_err!("Could not find file: {}", e))
+        .map_err(|e| anyhow!("Could not find file: {}", e))
         .and_then(|r| read_objs(r, &file_name))
 }
 
@@ -88,7 +86,7 @@ where
     file_mapping
         .get(&file_name)
         .map(|i| read_objs(archive.by_index(*i)?, file_name))
-        .unwrap_or_else(|| Err(format_err!("Could not find file {}", file_name)))
+        .unwrap_or_else(|| Err(anyhow!("Could not find file {}", file_name)))
 }
 
 fn read_optional_file<O, T>(
@@ -163,7 +161,7 @@ impl RawGtfs {
         } else if p.is_dir() {
             Self::from_directory(p)
         } else {
-            Err(format_err!(
+            Err(anyhow!(
                 "Could not read GTFS: {} is neither a file nor a directory",
                 path
             ))


### PR DESCRIPTION
The failure crate does not seems the way to go anymore, switch to anyhow that uses the standard `std::error::Error` Trait.

Also update to reqwest 0.10 and future 0.3 (the async/await compatible `futures` crate version).


The commits can be reviewed separatly.
