### PR TITLE
in case of errors, store the line in error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Read GTFS (public transit timetables) files"
 name = "gtfs-structures"
-version = "0.18.0"
+version = "0.18.1"
 authors = ["Tristram Gräbener <tristramg@gmail.com>"]
 repository = "https://github.com/rust-transit/gtfs-structure"
 license = "MIT"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,11 @@
 use thiserror::Error;
 
+#[derive(Debug)]
+pub struct LineError {
+    pub headers: Vec<String>,
+    pub values: Vec<String>,
+}
+
 /// An error that can occur when processing GTFS data.
 #[derive(Error, Debug)]
 pub enum Error {
@@ -27,6 +33,7 @@ pub enum Error {
         file_name: String,
         #[source]
         source: csv::Error,
+        line_in_error: Option<LineError>,
     },
     #[error(transparent)]
     Zip(#[from] zip::result::ZipError),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@ extern crate derivative;
 #[macro_use]
 extern crate serde_derive;
 
-mod error;
+pub mod error;
 mod gtfs;
 pub(crate) mod objects;
 mod raw_gtfs;


### PR DESCRIPTION
the line_number might not be enough, we store the whole line (+headers)

Note: this way the validator will be able to display the line without the need to reopen the file