### PR TITLE
Address #54

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Read GTFS (public transit timetables) files"
 name = "gtfs-structures"
-version = "0.18.1"
+version = "0.18.2"
 authors = ["Tristram Gräbener <tristramg@gmail.com>"]
 repository = "https://github.com/rust-transit/gtfs-structure"
 license = "MIT"

--- a/src/gtfs.rs
+++ b/src/gtfs.rs
@@ -78,6 +78,13 @@ impl Gtfs {
         RawGtfs::from_url(url).and_then(Gtfs::try_from)
     }
 
+    /// Asynchronously reads the GTFS from a remote url
+    /// The library must be built with the read-url feature
+    #[cfg(feature = "read-url")]
+    pub async fn from_url_async<U: reqwest::IntoUrl>(url: U) -> Result<Gtfs, Error> {
+        RawGtfs::from_url_async(url).await.and_then(Gtfs::try_from)
+    }
+
     pub fn from_reader<T: std::io::Read + std::io::Seek>(reader: T) -> Result<Gtfs, Error> {
         RawGtfs::from_reader(reader).and_then(Gtfs::try_from)
     }

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -422,7 +422,7 @@ impl fmt::Display for Agency {
     }
 }
 
-#[derive(Debug, Deserialize, Default, Serialize)]
+#[derive(Debug, Serialize, Deserialize, Default)]
 pub struct Shape {
     #[serde(rename = "shape_id")]
     pub id: String,
@@ -448,7 +448,7 @@ impl Id for Shape {
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct FareAttribute {
     #[serde(rename = "fare_id")]
     pub id: String,
@@ -527,7 +527,7 @@ impl Default for Transfers {
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct FeedInfo {
     #[serde(rename = "feed_publisher_name")]
     pub name: String,
@@ -537,12 +537,14 @@ pub struct FeedInfo {
     pub lang: String,
     #[serde(
         deserialize_with = "deserialize_option_date",
+        serialize_with = "serialize_option_date",
         rename = "feed_start_date",
         default
     )]
     pub start_date: Option<NaiveDate>,
     #[serde(
         deserialize_with = "deserialize_option_date",
+        serialize_with = "serialize_option_date",
         rename = "feed_end_date",
         default
     )]
@@ -582,6 +584,16 @@ where
         Some(Ok(s)) => Ok(Some(s)),
         Some(Err(e)) => Err(e),
         None => Ok(None),
+    }
+}
+
+fn serialize_option_date<S>(date: &Option<NaiveDate>, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer
+{
+    match date {
+        None => serializer.serialize_none(),
+        Some(d) => serializer.serialize_str(format!("{}{}{}", d.year(), d.month(), d.day()).as_str())
     }
 }
 

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -171,10 +171,10 @@ pub enum Exception {
     Deleted,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct CalendarDate {
     pub service_id: String,
-    #[serde(deserialize_with = "deserialize_date")]
+    #[serde(deserialize_with = "deserialize_date", serialize_with = "serialize_date")]
     pub date: NaiveDate,
     pub exception_type: Exception,
 }

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -244,18 +244,18 @@ impl fmt::Display for Stop {
     }
 }
 
-#[derive(Debug, Deserialize, Default)]
+#[derive(Debug, Serialize, Deserialize, Default)]
 pub struct RawStopTime {
     pub trip_id: String,
     /// Arrival time of the stop time.
     /// It's an option since the intermediate stops can have have no arrival
     /// and this arrival needs to be interpolated
-    #[serde(deserialize_with = "deserialize_optional_time")]
+    #[serde(deserialize_with = "deserialize_optional_time", serialize_with = "serialize_optional_time")]
     pub arrival_time: Option<u32>,
     /// Departure time of the stop time.
     /// It's an option since the intermediate stops can have have no departure
     /// and this departure needs to be interpolated
-    #[serde(deserialize_with = "deserialize_optional_time")]
+    #[serde(deserialize_with = "deserialize_optional_time", serialize_with = "serialize_optional_time")]
     pub departure_time: Option<u32>,
     pub stop_id: String,
     pub stop_sequence: u16,
@@ -619,6 +619,16 @@ where
     match s {
         None => Ok(None),
         Some(t) => Ok(Some(parse_time(&t).map_err(de::Error::custom)?)),
+    }
+}
+
+fn serialize_optional_time<S>(time: &Option<u32>, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    match time {
+        None => serializer.serialize_none(),
+        Some(t) => serializer.serialize_str(format!("{}", t).as_str()),
     }
 }
 

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -80,6 +80,25 @@ impl<'de> ::serde::Deserialize<'de> for RouteType {
     }
 }
 
+impl ::serde::Serialize for RouteType {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_u16(match self {
+            RouteType::Tramway   => 0,
+            RouteType::Subway    => 1,
+            RouteType::Rail      => 2,
+            RouteType::Bus       => 3,
+            RouteType::Ferry     => 4,
+            RouteType::CableCar  => 5,
+            RouteType::Gondola   => 6,
+            RouteType::Funicular => 7,
+            RouteType::Other(i)  => *i,
+        })
+    }
+}
+
 #[derive(Derivative)]
 #[derivative(Default(bound = ""))]
 #[derive(Debug, Serialize, Deserialize, Copy, Clone, PartialEq)]

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -286,7 +286,7 @@ impl StopTime {
     }
 }
 
-#[derive(Debug, Deserialize, Default)]
+#[derive(Debug, Serialize, Deserialize, Default)]
 pub struct Route {
     #[serde(rename = "route_id")]
     pub id: String,

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -102,15 +102,15 @@ impl Serialize for RouteType {
         S: Serializer,
     {
         serializer.serialize_u16(match self {
-            RouteType::Tramway   => 0,
-            RouteType::Subway    => 1,
-            RouteType::Rail      => 2,
-            RouteType::Bus       => 3,
-            RouteType::Ferry     => 4,
-            RouteType::CableCar  => 5,
-            RouteType::Gondola   => 6,
+            RouteType::Tramway => 0,
+            RouteType::Subway => 1,
+            RouteType::Rail => 2,
+            RouteType::Bus => 3,
+            RouteType::Ferry => 4,
+            RouteType::CableCar => 5,
+            RouteType::Gondola => 6,
             RouteType::Funicular => 7,
-            RouteType::Other(i)  => *i,
+            RouteType::Other(i) => *i,
         })
     }
 }
@@ -134,23 +134,50 @@ pub enum PickupDropOffType {
 pub struct Calendar {
     #[serde(rename = "service_id")]
     pub id: String,
-    #[serde(deserialize_with = "deserialize_bool", serialize_with = "serialize_bool")]
+    #[serde(
+        deserialize_with = "deserialize_bool",
+        serialize_with = "serialize_bool"
+    )]
     pub monday: bool,
-    #[serde(deserialize_with = "deserialize_bool", serialize_with = "serialize_bool")]
+    #[serde(
+        deserialize_with = "deserialize_bool",
+        serialize_with = "serialize_bool"
+    )]
     pub tuesday: bool,
-    #[serde(deserialize_with = "deserialize_bool", serialize_with = "serialize_bool")]
+    #[serde(
+        deserialize_with = "deserialize_bool",
+        serialize_with = "serialize_bool"
+    )]
     pub wednesday: bool,
-    #[serde(deserialize_with = "deserialize_bool", serialize_with = "serialize_bool")]
+    #[serde(
+        deserialize_with = "deserialize_bool",
+        serialize_with = "serialize_bool"
+    )]
     pub thursday: bool,
-    #[serde(deserialize_with = "deserialize_bool", serialize_with = "serialize_bool")]
+    #[serde(
+        deserialize_with = "deserialize_bool",
+        serialize_with = "serialize_bool"
+    )]
     pub friday: bool,
-    #[serde(deserialize_with = "deserialize_bool", serialize_with = "serialize_bool")]
+    #[serde(
+        deserialize_with = "deserialize_bool",
+        serialize_with = "serialize_bool"
+    )]
     pub saturday: bool,
-    #[serde(deserialize_with = "deserialize_bool", serialize_with = "serialize_bool")]
+    #[serde(
+        deserialize_with = "deserialize_bool",
+        serialize_with = "serialize_bool"
+    )]
     pub sunday: bool,
-    #[serde(deserialize_with = "deserialize_date", serialize_with = "serialize_date")]
+    #[serde(
+        deserialize_with = "deserialize_date",
+        serialize_with = "serialize_date"
+    )]
     pub start_date: NaiveDate,
-    #[serde(deserialize_with = "deserialize_date", serialize_with = "serialize_date")]
+    #[serde(
+        deserialize_with = "deserialize_date",
+        serialize_with = "serialize_date"
+    )]
     pub end_date: NaiveDate,
 }
 
@@ -209,7 +236,10 @@ pub enum Exception {
 #[derive(Debug, Deserialize, Serialize)]
 pub struct CalendarDate {
     pub service_id: String,
-    #[serde(deserialize_with = "deserialize_date", serialize_with = "serialize_date")]
+    #[serde(
+        deserialize_with = "deserialize_date",
+        serialize_with = "serialize_date"
+    )]
     pub date: NaiveDate,
     pub exception_type: Exception,
 }
@@ -263,12 +293,18 @@ pub struct RawStopTime {
     /// Arrival time of the stop time.
     /// It's an option since the intermediate stops can have have no arrival
     /// and this arrival needs to be interpolated
-    #[serde(deserialize_with = "deserialize_optional_time", serialize_with = "serialize_optional_time")]
+    #[serde(
+        deserialize_with = "deserialize_optional_time",
+        serialize_with = "serialize_optional_time"
+    )]
     pub arrival_time: Option<u32>,
     /// Departure time of the stop time.
     /// It's an option since the intermediate stops can have have no departure
     /// and this departure needs to be interpolated
-    #[serde(deserialize_with = "deserialize_optional_time", serialize_with = "serialize_optional_time")]
+    #[serde(
+        deserialize_with = "deserialize_optional_time",
+        serialize_with = "serialize_optional_time"
+    )]
     pub departure_time: Option<u32>,
     pub stop_id: String,
     pub stop_sequence: u16,
@@ -525,9 +561,9 @@ impl Serialize for Transfers {
         S: Serializer,
     {
         match self {
-            Transfers::NoTransfer =>     serializer.serialize_u16(0),
+            Transfers::NoTransfer => serializer.serialize_u16(0),
             Transfers::UniqueTransfer => serializer.serialize_u16(1),
-            Transfers::TwoTransfers =>   serializer.serialize_u16(2),
+            Transfers::TwoTransfers => serializer.serialize_u16(2),
             Transfers::Other(a) => serializer.serialize_u16(*a),
             Transfers::Unlimited => serializer.serialize_none(),
         }
@@ -602,11 +638,13 @@ where
 
 fn serialize_option_date<S>(date: &Option<NaiveDate>, serializer: S) -> Result<S::Ok, S::Error>
 where
-    S: Serializer
+    S: Serializer,
 {
     match date {
         None => serializer.serialize_none(),
-        Some(d) => serializer.serialize_str(format!("{}{}{}", d.year(), d.month(), d.day()).as_str())
+        Some(d) => {
+            serializer.serialize_str(format!("{}{}{}", d.year(), d.month(), d.day()).as_str())
+        }
     }
 }
 
@@ -681,7 +719,7 @@ where
 
 fn serialize_bool<'ser, S>(value: &bool, serializer: S) -> Result<S::Ok, S::Error>
 where
-    S: Serializer
+    S: Serializer,
 {
     if *value {
         serializer.serialize_u8(1)

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -81,7 +81,7 @@ impl<'de> ::serde::Deserialize<'de> for RouteType {
 
 #[derive(Derivative)]
 #[derivative(Default(bound = ""))]
-#[derive(Debug, Deserialize, Copy, Clone, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Copy, Clone, PartialEq)]
 pub enum PickupDropOffType {
     #[derivative(Default)]
     #[serde(rename = "0")]
@@ -301,7 +301,7 @@ impl fmt::Display for Route {
     }
 }
 
-#[derive(Debug, Deserialize, Default)]
+#[derive(Debug, Serialize, Deserialize, Default)]
 pub struct RawTrip {
     #[serde(rename = "trip_id")]
     pub id: String,
@@ -361,7 +361,7 @@ impl fmt::Display for Trip {
     }
 }
 
-#[derive(Debug, Deserialize, Default)]
+#[derive(Debug, Serialize, Deserialize, Default)]
 pub struct Agency {
     #[serde(rename = "agency_id")]
     pub id: Option<String>,
@@ -402,7 +402,7 @@ impl fmt::Display for Agency {
     }
 }
 
-#[derive(Debug, Deserialize, Default)]
+#[derive(Debug, Deserialize, Default, Serialize)]
 pub struct Shape {
     #[serde(rename = "shape_id")]
     pub id: String,
@@ -453,7 +453,7 @@ impl Type for FareAttribute {
     }
 }
 
-#[derive(Debug, Deserialize, Copy, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, Copy, Clone, PartialEq)]
 pub enum PaymentMethod {
     #[serde(rename = "0")]
     Aboard,

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -1,5 +1,6 @@
 use chrono::{Datelike, NaiveDate, Weekday};
 use serde::de::{self, Deserialize, Deserializer};
+use serde::ser::{Serializer};
 use std::fmt;
 use std::sync::Arc;
 
@@ -94,27 +95,27 @@ pub enum PickupDropOffType {
     CoordinateWithDriver,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct Calendar {
     #[serde(rename = "service_id")]
     pub id: String,
-    #[serde(deserialize_with = "deserialize_bool")]
+    #[serde(deserialize_with = "deserialize_bool", serialize_with = "serialize_bool")]
     pub monday: bool,
-    #[serde(deserialize_with = "deserialize_bool")]
+    #[serde(deserialize_with = "deserialize_bool", serialize_with = "serialize_bool")]
     pub tuesday: bool,
-    #[serde(deserialize_with = "deserialize_bool")]
+    #[serde(deserialize_with = "deserialize_bool", serialize_with = "serialize_bool")]
     pub wednesday: bool,
-    #[serde(deserialize_with = "deserialize_bool")]
+    #[serde(deserialize_with = "deserialize_bool", serialize_with = "serialize_bool")]
     pub thursday: bool,
-    #[serde(deserialize_with = "deserialize_bool")]
+    #[serde(deserialize_with = "deserialize_bool", serialize_with = "serialize_bool")]
     pub friday: bool,
-    #[serde(deserialize_with = "deserialize_bool")]
+    #[serde(deserialize_with = "deserialize_bool", serialize_with = "serialize_bool")]
     pub saturday: bool,
-    #[serde(deserialize_with = "deserialize_bool")]
+    #[serde(deserialize_with = "deserialize_bool", serialize_with = "serialize_bool")]
     pub sunday: bool,
-    #[serde(deserialize_with = "deserialize_date")]
+    #[serde(deserialize_with = "deserialize_date", serialize_with = "serialize_date")]
     pub start_date: NaiveDate,
-    #[serde(deserialize_with = "deserialize_date")]
+    #[serde(deserialize_with = "deserialize_date", serialize_with = "serialize_date")]
     pub end_date: NaiveDate,
 }
 
@@ -530,6 +531,13 @@ where
     NaiveDate::parse_from_str(&s, "%Y%m%d").map_err(serde::de::Error::custom)
 }
 
+fn serialize_date<'ser, S>(date: &NaiveDate, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    serializer.serialize_str(format!("{}{}{}", date.year(), date.month(), date.day()).as_str())
+}
+
 fn deserialize_option_date<'de, D>(deserializer: D) -> Result<Option<NaiveDate>, D::Error>
 where
     D: Deserializer<'de>,
@@ -613,5 +621,16 @@ where
             "Invalid value `{}`, expected 0 or 1",
             s
         ))),
+    }
+}
+
+fn serialize_bool<'ser, S>(value: &bool, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer
+{
+    if *value {
+        serializer.serialize_u8(1)
+    } else {
+        serializer.serialize_u8(0)
     }
 }

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -60,10 +60,10 @@ impl Default for RouteType {
     }
 }
 
-impl<'de> ::serde::Deserialize<'de> for RouteType {
+impl<'de> Deserialize<'de> for RouteType {
     fn deserialize<D>(deserializer: D) -> Result<RouteType, D::Error>
     where
-        D: ::serde::Deserializer<'de>,
+        D: Deserializer<'de>,
     {
         let i = u16::deserialize(deserializer)?;
         Ok(match i {
@@ -490,10 +490,10 @@ pub enum Transfers {
     Other(u16),
 }
 
-impl<'de> ::serde::Deserialize<'de> for Transfers {
+impl<'de> Deserialize<'de> for Transfers {
     fn deserialize<D>(deserializer: D) -> Result<Transfers, D::Error>
     where
-        D: ::serde::Deserializer<'de>,
+        D: Deserializer<'de>,
     {
         let i = Option::<u16>::deserialize(deserializer)?;
         Ok(match i {
@@ -503,6 +503,21 @@ impl<'de> ::serde::Deserialize<'de> for Transfers {
             Some(a) => Transfers::Other(a),
             None => Transfers::default(),
         })
+    }
+}
+
+impl ::serde::Serialize for Transfers {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            Transfers::NoTransfer =>     serializer.serialize_u16(0),
+            Transfers::UniqueTransfer => serializer.serialize_u16(1),
+            Transfers::TwoTransfers =>   serializer.serialize_u16(2),
+            Transfers::Other(a) => serializer.serialize_u16(*a),
+            Transfers::Unlimited => serializer.serialize_none(),
+        }
     }
 }
 

--- a/src/raw_gtfs.rs
+++ b/src/raw_gtfs.rs
@@ -248,7 +248,7 @@ impl RawGtfs {
     /// Non-blocking read the raw GTFS from a remote url
     /// The library must be built with the read-url feature
     #[cfg(feature = "read-url")]
-    pub async fn from_url_async(url: &str) -> Result<Self, Error> {
+    pub async fn from_url_async<U: reqwest::IntoUrl>(url: U) -> Result<Self, Error> {
         let res = reqwest::get(url).await?.bytes().await?;
 
         let reader = std::io::Cursor::new(res);


### PR DESCRIPTION
This pull request implements the `Serialize` trait on all the structs in `objects.rs`.
Other minor improvements to the code (move deserialize_location_type into a Deserialize trait implementation and remove some useless path specification to traits of Serde that had been already imported)