### PR TITLE
add field for optional trip_headsign in Trip structs

### DIFF
--- a/src/gtfs.rs
+++ b/src/gtfs.rs
@@ -223,6 +223,7 @@ fn create_trips(
         route_id: rt.route_id,
         stop_times: vec![],
         shape_id: rt.shape_id,
+        trip_headsign: rt.trip_headsign,
     }));
     for s in raw_stop_times {
         let trip = &mut trips

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -388,6 +388,7 @@ pub struct RawTrip {
     pub service_id: String,
     pub route_id: String,
     pub shape_id: Option<String>,
+    pub trip_headsign: Option<String>, 
 }
 
 impl Type for RawTrip {
@@ -419,6 +420,7 @@ pub struct Trip {
     pub route_id: String,
     pub stop_times: Vec<StopTime>,
     pub shape_id: Option<String>,
+    pub trip_headsign: Option<String>, 
 }
 
 impl Type for Trip {


### PR DESCRIPTION
In the GTFS specification, `trips` have an optional `trip_headsign` field.
To reflect this in the data structures, I added a field to the `Trip` and `RawTrip` structs using Rust's `Option` type.