### PR TITLE
Add missing filename to error

### DIFF
--- a/src/raw_gtfs.rs
+++ b/src/raw_gtfs.rs
@@ -90,7 +90,7 @@ where
         .unwrap_or_else(|| "invalid_file_name")
         .to_string();
     File::open(path)
-        .map_err(|e| Error::MissingFile(format!("Could not find file: {}", e)))
+        .map_err(|e| Error::MissingFile(format!("Could not find file: {} - {})", file_name, e)))
         .and_then(|r| read_objs(r, &file_name))
 }
 


### PR DESCRIPTION
I'm reading a folder with the following code:

```rust
gtfs_structures::Gtfs::new("test_data/optimisation_route_trips")
```

If one of the mandatory files is not there, I'll get an error message which does not hint me about what is the missing file exactly:

```
MissingFile("Could not find file: No such file or directory (os error 2)")'
```

With the following PR, the error message mentions the file name:

```
MissingFile("Could not find file: stops.txt - No such file or directory (os error 2))")'
```

Currently I just store the file_name, but it could be better to use the full path.