### PR TITLE
Implement Translations

### DIFF
--- a/fixtures/basic/translations.txt
+++ b/fixtures/basic/translations.txt
@@ -1,0 +1,2 @@
+table_name,field_name,language,translation,field_value
+agency,agency_name,nl,BIBUS,BIBUS

--- a/fixtures/basic/translations.txt
+++ b/fixtures/basic/translations.txt
@@ -1,2 +1,3 @@
-table_name,field_name,language,translation,field_value
-agency,agency_name,nl,BIBUS,BIBUS
+table_name,field_name,language,translation,field_value,record_id,record_sub_id
+stops,stop_name,nl,Stop Gebied,,stop1,
+stops,stop_name,fr,Arrêt Région,"Stop Area",,

--- a/src/error.rs
+++ b/src/error.rs
@@ -15,6 +15,8 @@ pub enum Error {
     ReferenceError(String),
     #[error("Could not read GTFS: {0} is neither a file nor a directory")]
     NotFileNorDirectory(String),
+    #[error("Invalid translation: {0}")]
+    InvalidTranslation(String),
     #[error("'{0}' is not a valid time")]
     InvalidTime(String),
     #[error("'{0}' is not a valid color")]

--- a/src/gtfs.rs
+++ b/src/gtfs.rs
@@ -194,6 +194,15 @@ impl Gtfs {
         }
     }
 
+    pub fn get_trip_translated(
+        &self,
+        id: &str,
+        language: &str
+    ) -> Result<Trip, Error> {
+        let trip = self.get_trip(id)?;
+        Ok(trip.to_owned().translate(self, language))
+    }
+
     pub fn get_route<'a>(&'a self, id: &str) -> Result<&'a Route, Error> {
         match self.routes.get(id) {
             Some(route) => Ok(route),

--- a/src/gtfs.rs
+++ b/src/gtfs.rs
@@ -20,6 +20,8 @@ pub struct Gtfs {
     pub shapes: HashMap<String, Vec<Shape>>,
     pub fare_attributes: HashMap<String, FareAttribute>,
     pub feed_info: Vec<FeedInfo>,
+    pub translations_by_id: HashMap<TranslationByIdKey, String>,
+    pub translations_by_value: HashMap<TranslationByValueKey, String>,
 }
 
 impl TryFrom<RawGtfs> for Gtfs {
@@ -27,6 +29,9 @@ impl TryFrom<RawGtfs> for Gtfs {
     fn try_from(raw: RawGtfs) -> Result<Gtfs, Error> {
         let stops = to_stop_map(raw.stops?);
         let trips = create_trips(raw.trips?, raw.stop_times?, &stops)?;
+        let (translations_by_id, translations_by_value) = create_translations(
+            raw.translations.unwrap_or(Ok(vec!()))?
+        )?;
 
         Ok(Gtfs {
             stops,
@@ -40,6 +45,8 @@ impl TryFrom<RawGtfs> for Gtfs {
             calendar_dates: to_calendar_dates(
                 raw.calendar_dates.unwrap_or_else(|| Ok(Vec::new()))?,
             ),
+            translations_by_id,
+            translations_by_value,
             read_duration: raw.read_duration,
         })
     }
@@ -252,4 +259,60 @@ fn create_trips(
             .sort_by(|a, b| a.stop_sequence.cmp(&b.stop_sequence));
     }
     Ok(trips)
+}
+
+fn create_translations(
+    raw_translations: Vec<Translation>
+) -> Result<(
+    HashMap<TranslationByIdKey, String>,
+    HashMap<TranslationByValueKey, String>
+), Error> {
+    let mut translations_by_id = HashMap::new();
+    let mut translations_by_value = HashMap::new();
+
+    for translation in raw_translations {
+        if translation.record_id.is_some() {
+            // Make sure it is not forbidden
+            if translation.field_value.is_some() ||
+                translation.table_name == "feed_info".to_string() {
+                return Err(Error::InvalidTranslation(
+                        "record_id was defined when it was forbidden".to_string()
+                ));
+            }
+
+            // Make sure record_sub_id is there if and only if it is required
+            if translation.table_name == "stop_times".to_string() &&
+                translation.record_sub_id.is_none() {
+                return Err(Error::InvalidTranslation(
+                        "record_sub_id was not set when it was required".to_string()
+                ));
+            }
+
+            translations_by_id.insert(TranslationByIdKey {
+                table_name: translation.table_name,
+                field_name: translation.field_name,
+                language: translation.language,
+                record_id: translation.record_id.unwrap(),
+                record_sub_id: translation.record_sub_id,
+            }, translation.translation);
+        } else if translation.field_value.is_some() {
+            // Make sure it is not forbidden
+            if translation.record_id.is_some() ||
+                translation.record_sub_id.is_some() ||
+                translation.table_name == "feed_info".to_string() {
+                return Err(Error::InvalidTranslation(
+                        "field_value was defined when it was forbidden".to_string()
+                ));
+            }
+
+            translations_by_value.insert(TranslationByValueKey {
+                table_name: translation.table_name,
+                field_name: translation.field_name,
+                language: translation.language,
+                field_value: translation.field_value.unwrap(),
+            }, translation.translation);
+        }
+    }
+
+    return Ok((translations_by_id, translations_by_value));
 }

--- a/src/gtfs.rs
+++ b/src/gtfs.rs
@@ -140,7 +140,7 @@ impl Gtfs {
         result
     }
 
-    fn translate(
+    pub fn translate(
         &self,
         table_name: &str,
         field_name: &str,
@@ -184,63 +184,7 @@ impl Gtfs {
         language: &str
     ) -> Result<Stop, Error> {
         let stop = self.get_stop(id)?;
-        Ok(Stop {
-            id: stop.id.clone(),
-            code: stop.code.as_ref().map(|code| 
-                self.translate(
-                    "stops",
-                    "stop_code",
-                    language,
-                    &stop.id,
-                    None,
-                    &code
-                )
-            ),
-            name: self.translate(
-                "stops",
-                "stop_name",
-                language,
-                &stop.id,
-                None,
-                &stop.name
-            ),
-            description: self.translate(
-                "stops",
-                "stop_desc",
-                language,
-                &stop.id,
-                None,
-                &stop.description
-            ),
-            location_type: stop.location_type,
-            parent_station: stop.parent_station.clone(),
-            zone_id: stop.zone_id.clone(),
-            url: stop.code.as_ref().map(|url|
-                self.translate(
-                    "stops",
-                    "stop_url",
-                    language,
-                    &stop.id,
-                    None,
-                    &url
-                )
-            ),
-            longitude: stop.longitude,
-            latitude: stop.latitude,
-            timezone: stop.timezone.clone(),
-            wheelchair_boarding: stop.wheelchair_boarding,
-            level_id: stop.level_id.clone(),
-            platform_code: stop.code.as_ref().map(|platform_code|
-                self.translate(
-                    "stops",
-                    "platform_code",
-                    language,
-                    &stop.id,
-                    None,
-                    &platform_code
-                )
-            ),
-        })
+        Ok(stop.to_owned().translate(self, language))
     }
 
     pub fn get_trip<'a>(&'a self, id: &str) -> Result<&'a Trip, Error> {

--- a/src/gtfs.rs
+++ b/src/gtfs.rs
@@ -210,6 +210,15 @@ impl Gtfs {
         }
     }
 
+    pub fn get_route_translated(
+        &self,
+        id: &str,
+        language: &str
+    ) -> Result<Route, Error> {
+        let route = self.get_route(id)?;
+        Ok(route.to_owned().translate(self, language))
+    }
+
     pub fn get_calendar<'a>(&'a self, id: &str) -> Result<&'a Calendar, Error> {
         match self.calendar.get(id) {
             Some(calendar) => Ok(calendar),

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -13,7 +13,20 @@ pub trait Type {
     fn object_type(&self) -> ObjectType;
 }
 
-#[derive(Debug, Serialize, Eq, PartialEq, Hash)]
+#[derive(Derivative)]
+#[derivative(Default(bound = ""))]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub struct Translation {
+    pub table_name: String,
+    pub field_name: String,
+    pub language: String,
+    pub translation: String,
+    pub record_id: Option<String>,
+    pub record_sub_id: Option<String>,
+    pub field_value: Option<String>,
+}
+
+#[derive(Debug, Serialize, Eq, PartialEq, Hash, Clone)]
 pub enum ObjectType {
     Agency,
     Stop,
@@ -22,6 +35,8 @@ pub enum ObjectType {
     Calendar,
     Shape,
     Fare,
+    StopTime,
+    FeedInfo,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Serialize)]

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -467,6 +467,25 @@ pub struct StopTime {
     pub timepoint: bool,
 }
 
+impl Translatable for StopTime {
+    fn translate(&self, gtfs: &Gtfs, language: &str) -> Self {
+        StopTime {
+            arrival_time: self.arrival_time.clone(),
+            stop: Arc::new(self.stop.translate(gtfs, language)),
+            departure_time: self.departure_time.clone(),
+            pickup_type: self.pickup_type.clone(),
+            drop_off_type: self.drop_off_type.clone(),
+            stop_sequence: self.stop_sequence,
+            // Headsign can't be translated as we do not have a reference to this StopTime's Trip
+            stop_headsign: self.stop_headsign.clone(),
+            continuous_pickup: self.continuous_pickup.clone(),
+            continuous_drop_off: self.continuous_drop_off.clone(),
+            shape_dist_traveled: self.shape_dist_traveled,
+            timepoint: self.timepoint
+        }
+    }
+}
+
 impl StopTime {
     pub fn from(stop_time_gtfs: &RawStopTime, stop: Arc<Stop>) -> Self {
         Self {
@@ -628,6 +647,38 @@ impl Type for Trip {
 impl Id for Trip {
     fn id(&self) -> &str {
         &self.id
+    }
+}
+
+impl Translatable for Trip {
+    fn translate(&self, gtfs: &Gtfs, language: &str) -> Self {
+        Trip {
+            id: self.id.clone(),
+            service_id: self.service_id.clone(),
+            route_id: self.route_id.clone(),
+            stop_times: self.stop_times.iter().map(|stop_time| stop_time.translate(gtfs, language)).collect(),
+            shape_id: self.shape_id.clone(),
+            trip_headsign: self.trip_headsign.as_ref().map(|headsign| gtfs.translate(
+                "trips",
+                "trip_headsign",
+                language,
+                &self.id,
+                None,
+                &headsign
+            )),
+            trip_short_name: self.trip_short_name.as_ref().map(|short_name| gtfs.translate(
+                "trips",
+                "trip_short_name",
+                language,
+                &self.id,
+                None,
+                &short_name
+            )),
+            direction_id: self.direction_id.clone(),
+            block_id: self.block_id.clone(),
+            wheelchair_accessible: self.wheelchair_accessible.clone(),
+            bikes_allowed: self.bikes_allowed.clone(),
+        }
     }
 }
 

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -1,3 +1,4 @@
+use crate::Gtfs;
 use chrono::{Datelike, NaiveDate, Weekday};
 use rgb::RGB8;
 use serde::de::{self, Deserialize, Deserializer};
@@ -11,6 +12,10 @@ pub trait Id {
 
 pub trait Type {
     fn object_type(&self) -> ObjectType;
+}
+
+pub trait Translatable {
+    fn translate(&self, gtfs: &Gtfs, language: &str) -> Self;
 }
 
 #[derive(Derivative)]
@@ -341,6 +346,68 @@ impl Type for Stop {
 impl Id for Stop {
     fn id(&self) -> &str {
         &self.id
+    }
+}
+
+impl Translatable for Stop {
+    fn translate(&self, gtfs: &Gtfs, language: &str) -> Self {
+        Stop {
+            id: self.id.clone(),
+            code: self.code.as_ref().map(|code| 
+                gtfs.translate(
+                    "stops",
+                    "stop_code",
+                    language,
+                    &self.id,
+                    None,
+                    &code
+                )
+            ),
+            name: gtfs.translate(
+                "stops",
+                "stop_name",
+                language,
+                &self.id,
+                None,
+                &self.name
+            ),
+            description: gtfs.translate(
+                "stops",
+                "stop_desc",
+                language,
+                &self.id,
+                None,
+                &self.description
+            ),
+            location_type: self.location_type,
+            parent_station: self.parent_station.clone(),
+            zone_id: self.zone_id.clone(),
+            url: self.code.as_ref().map(|url|
+                gtfs.translate(
+                    "stops",
+                    "stop_url",
+                    language,
+                    &self.id,
+                    None,
+                    &url
+                )
+            ),
+            longitude: self.longitude,
+            latitude: self.latitude,
+            timezone: self.timezone.clone(),
+            wheelchair_boarding: self.wheelchair_boarding,
+            level_id: self.level_id.clone(),
+            platform_code: self.code.as_ref().map(|platform_code|
+                gtfs.translate(
+                    "stops",
+                    "platform_code",
+                    language,
+                    &self.id,
+                    None,
+                    &platform_code
+                )
+            ),
+        }
     }
 }
 

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -548,6 +548,53 @@ impl Id for Route {
     }
 }
 
+impl Translatable for Route {
+    fn translate(&self, gtfs: &Gtfs, language: &str) -> Route {
+        Route {
+            id: self.id.clone(),
+            short_name: gtfs.translate(
+                "routes",
+                "route_short_name",
+                language,
+                &self.id,
+                None,
+                &self.short_name
+            ),
+            long_name: gtfs.translate(
+                "routes",
+                "route_long_name",
+                language,
+                &self.id,
+                None,
+                &self.long_name
+            ),
+            desc: self.desc.as_ref().map(|desc| gtfs.translate(
+                    "routes",
+                    "route_desc",
+                    language,
+                    &self.id,
+                    None,
+                    &desc
+            )),
+            route_type: self.route_type.clone(),
+            url: self.url.as_ref().map(|url| gtfs.translate(
+                    "routes",
+                    "route_url",
+                    language,
+                    &self.id,
+                    None,
+                    &url
+            )),
+            agency_id: self.agency_id.clone(),
+            route_order: self.route_order.clone(),
+            route_color: self.route_color.clone(),
+            route_text_color: self.route_text_color.clone(),
+            continuous_pickup: self.continuous_pickup.clone(),
+            continuous_drop_off: self.continuous_drop_off.clone(),
+        }
+    }
+}
+
 impl fmt::Display for Route {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if !self.long_name.is_empty() {

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -26,6 +26,23 @@ pub struct Translation {
     pub field_value: Option<String>,
 }
 
+#[derive(Debug, Eq, PartialEq, Hash)]
+pub struct TranslationByIdKey {
+    pub table_name: String,
+    pub field_name: String,
+    pub language: String,
+    pub record_id: String,
+    pub record_sub_id: Option<String>,
+}
+
+#[derive(Debug, Eq, PartialEq, Hash)]
+pub struct TranslationByValueKey {
+    pub table_name: String,
+    pub field_name: String,
+    pub language: String,
+    pub field_value: String,
+}
+
 #[derive(Debug, Serialize, Eq, PartialEq, Hash, Clone)]
 pub enum ObjectType {
     Agency,

--- a/src/raw_gtfs.rs
+++ b/src/raw_gtfs.rs
@@ -1,3 +1,4 @@
+use crate::objects::Translation;
 use crate::objects::*;
 use crate::Error;
 use chrono::Utc;
@@ -25,6 +26,7 @@ pub struct RawGtfs {
     pub stop_times: Result<Vec<RawStopTime>, Error>,
     pub files: Vec<String>,
     pub sha256: Option<String>,
+    pub translations: Option<Result<Vec<Translation>, Error>>,
 }
 
 fn read_objs<T, O>(mut reader: T, file_name: &str) -> Result<Vec<O>, Error>
@@ -228,6 +230,7 @@ impl RawGtfs {
             shapes: read_objs_from_optional_path(&p, "shapes.txt"),
             fare_attributes: read_objs_from_optional_path(&p, "fare_attributes.txt"),
             feed_info: read_objs_from_optional_path(&p, "feed_info.txt"),
+            translations: read_objs_from_optional_path(&p, "translations.txt"),
             read_duration: Utc::now().signed_duration_since(now).num_milliseconds(),
             files,
             sha256: None,
@@ -280,6 +283,7 @@ impl RawGtfs {
                 "fare_attributes.txt",
                 "feed_info.txt",
                 "shapes.txt",
+                "translations.txt",
             ] {
                 let path = std::path::Path::new(archive_file.name());
                 if path.file_name() == Some(std::ffi::OsStr::new(gtfs_file)) {
@@ -300,6 +304,7 @@ impl RawGtfs {
             fare_attributes: read_optional_file(&file_mapping, &mut archive, "fare_attributes.txt"),
             feed_info: read_optional_file(&file_mapping, &mut archive, "feed_info.txt"),
             shapes: read_optional_file(&file_mapping, &mut archive, "shapes.txt"),
+            translations: read_optional_file(&file_mapping, &mut archive, "translations.txt"),
             read_duration: Utc::now().signed_duration_since(now).num_milliseconds(),
             files,
             sha256: Some(format!("{:x}", hash)),

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -337,17 +337,12 @@ fn read_translations() {
     assert!(gtfs.translations.is_some());
     let translations_res = gtfs.translations.unwrap();
     assert!(translations_res.is_ok());
-    let translations = translations_res.unwrap();
-    assert_eq!(1, translations.len());
-    assert_eq!(translations[0], Translation {
-        table_name: "agency".to_string(),
-        field_name: "agency_name".to_string(),
-        language: "nl".to_string(),
-        translation: "BIBUS".to_string(),
-        record_id: None,
-        record_sub_id: None,
-        field_value: Some(
-            "BIBUS".to_string(),
-        ),
-    })
+}
+
+#[test]
+fn translations() {
+    let gtfs = Gtfs::from_path("fixtures/basic").expect("impossible to read gtfs");
+    assert_eq!(gtfs.get_stop_translated("stop1", "nl").unwrap().name, "Stop Gebied");
+    assert_eq!(gtfs.get_stop_translated("stop1", "fr").unwrap().name, "Arrêt Région");
+    assert_eq!(gtfs.get_stop_translated("stop1", "en").unwrap().name, "Stop Area");
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -235,7 +235,7 @@ fn display() {
 #[test]
 fn path_files() {
     let gtfs = RawGtfs::from_path("fixtures/basic").expect("impossible to read gtfs");
-    assert_eq!(gtfs.files.len(), 10);
+    assert_eq!(gtfs.files.len(), 11);
 }
 
 #[test]
@@ -329,4 +329,25 @@ fn sorted_shapes() {
             (11, 37.65863, -122.30839),
         ]
     );
+}
+
+#[test]
+fn read_translations() {
+    let gtfs = RawGtfs::from_path("fixtures/basic").expect("impossible to read gtfs");
+    assert!(gtfs.translations.is_some());
+    let translations_res = gtfs.translations.unwrap();
+    assert!(translations_res.is_ok());
+    let translations = translations_res.unwrap();
+    assert_eq!(1, translations.len());
+    assert_eq!(translations[0], Translation {
+        table_name: "agency".to_string(),
+        field_name: "agency_name".to_string(),
+        language: "nl".to_string(),
+        translation: "BIBUS".to_string(),
+        record_id: None,
+        record_sub_id: None,
+        field_value: Some(
+            "BIBUS".to_string(),
+        ),
+    })
 }


### PR DESCRIPTION
As requested in #72 this PR add support for translations through the following methods in `Gtfs`:

- get_stop_translated
- get_trip_translated
- get_route_translated

Future objects can be translated similarly to `Stop`, `Trip` and `Route` by implementing the `Translatable` trait using the `translate` function in `Gtfs`.