### PR TITLE
Add trim fields option to csv reader

### DIFF
--- a/src/raw_gtfs.rs
+++ b/src/raw_gtfs.rs
@@ -48,6 +48,7 @@ where
 
     let mut reader = csv::ReaderBuilder::new()
         .flexible(true)
+        .trim(csv::Trim::Fields)
         .from_reader(chained);
     // We store the headers to be able to return them in case of errors
     let headers = reader


### PR DESCRIPTION
Some GTFS feeds are not particularly clean. I found that adding the option to the CSV reader to trim whitespace in field values allows parsing some of these unclean CSVs.

This allows reading numerical values like `" 3"` (note the space). Example of a broken feed is [New York's MTA Bus Service in the Bronx](http://web.mta.info/developers/data/nyct/bus/google_transit_bronx.zip).

This will change string values with leading/trailing whitespace, but I think it's OK as these are not really meaningful.