### PR TITLE
Bump all dependencies versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Read GTFS (public transit timetables) files"
 name = "gtfs-structures"
-version = "0.23.0"
+version = "0.24.0"
 authors = ["Tristram Gräbener <tristramg@gmail.com>", "Antoine Desbordes <antoine.desbordes@gmail.com>"]
 repository = "https://github.com/rust-transit/gtfs-structure"
 license = "MIT"
@@ -12,17 +12,17 @@ default = ["read-url"]
 read-url = ["reqwest", "futures"]
 
 [dependencies]
-bytes = "0.5"
+bytes = "1"
 csv = "1.1"
 derivative = "2.1"
 serde = "1.0"
 serde_derive = "1.0"
 chrono = "0.4"
-itertools = "0.9"
+itertools = "0.10"
 sha2 = "0.9"
 zip = "0.5"
 thiserror = "1"
 rgb = "0.8"
 
 futures = { version = "0.3", optional = true }
-reqwest = { version = "0.10", optional = true, features = ["blocking", "rustls-tls"], default-features = false }
+reqwest = { version = "0.11", optional = true, features = ["blocking"]}


### PR DESCRIPTION
The most important change here is the `reqwest` update. This makes it possible to now use the default features and use `default-tls` instead of `rust-tls`.

fixes https://github.com/rust-transit/gtfs-structure/issues/78