### PR TITLE
Allow not to parse stop_times

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,6 +24,10 @@ jobs:
         with:
           command: test
           args: --all-features
+      - uses: actions-rs/cargo@v1 # we also test without the default `read-url` feature
+        with:
+          command: test
+          args: --no-default-features
 
   lints:
     name: Lints

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Read GTFS (public transit timetables) files"
 name = "gtfs-structures"
-version = "0.27.0"
+version = "0.28.0"
 authors = ["Tristram Gräbener <tristramg@gmail.com>", "Antoine Desbordes <antoine.desbordes@gmail.com>"]
 repository = "https://github.com/rust-transit/gtfs-structure"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Read GTFS (public transit timetables) files"
 name = "gtfs-structures"
-version = "0.28.0"
+version = "0.27.0"
 authors = ["Tristram Gräbener <tristramg@gmail.com>", "Antoine Desbordes <antoine.desbordes@gmail.com>"]
 repository = "https://github.com/rust-transit/gtfs-structure"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Read GTFS (public transit timetables) files"
 name = "gtfs-structures"
-version = "0.26.0"
+version = "0.27.0"
 authors = ["Tristram Gräbener <tristramg@gmail.com>", "Antoine Desbordes <antoine.desbordes@gmail.com>"]
 repository = "https://github.com/rust-transit/gtfs-structure"
 license = "MIT"

--- a/examples/gtfs_raw_reader.rs
+++ b/examples/gtfs_raw_reader.rs
@@ -1,0 +1,15 @@
+fn main() {
+    /* Gtfs::new will try to guess if you provide a path, a local zip file or a remote zip file.
+       You can also use Gtfs::from_path, Gtfs::from_url
+    */
+    let gtfs = gtfs_structures::GtfsReader::default()
+        .read_stop_times(false)
+        .raw()
+        .read("fixtures/basic")
+        .expect("impossible to read gtfs");
+    gtfs.print_stats();
+
+    let routes = gtfs.routes.expect("impossible to read routes");
+    let route_1 = routes.first().expect("no route");
+    println!("{}: {:?}", route_1.short_name, route_1);
+}

--- a/examples/gtfs_reader.rs
+++ b/examples/gtfs_reader.rs
@@ -1,0 +1,15 @@
+fn main() {
+    /* Gtfs::new will try to guess if you provide a path, a local zip file or a remote zip file.
+       You can also use Gtfs::from_path, Gtfs::from_url
+    */
+    let gtfs = gtfs_structures::GtfsReader::default()
+        .read_stop_times(false)
+        .read("fixtures/basic")
+        .expect("impossible to read gtfs");
+    gtfs.print_stats();
+
+    println!("there are {} stops in the gtfs", gtfs.stops.len());
+
+    let route_1 = gtfs.routes.get("1").expect("no route 1");
+    println!("{}: {:?}", route_1.short_name, route_1);
+}

--- a/src/gtfs.rs
+++ b/src/gtfs.rs
@@ -9,13 +9,13 @@ use std::sync::Arc;
 ///
 /// This structure is easier to use than the [RawGtfs] structure as some relationships are parsed to be easier to use.
 ///
+/// If you want to configure the behaviour (e.g. skipping : [StopTime]), see [crate::GtfsReader] for more personalisation
+///
 /// This is probably the entry point you want to use:
 /// ```
-/// # fn main() -> Result<(), gtfs_structures::error::Error> {
 /// let gtfs = gtfs_structures::Gtfs::new("fixtures/zips/gtfs.zip")?;
 /// assert_eq!(gtfs.stops.len(), 5);
-/// #     Ok(())
-/// # }
+/// # Ok::<(), gtfs_structures::error::Error>(())
 /// ```
 ///
 /// The [StopTime] are accessible from the [Trip]

--- a/src/gtfs_reader.rs
+++ b/src/gtfs_reader.rs
@@ -1,0 +1,73 @@
+use crate::{Error, Gtfs, RawGtfs};
+use std::convert::TryFrom;
+use std::path::Path;
+
+/// Allows to parameterize how the parsing library behaves
+///
+/// ```
+///let gtfs = gtfs_structures::GtfsReader::default()
+///    .without_stop_times()
+///    .read("fixtures/zips/gtfs.zip")?;
+///assert_eq!(0, gtfs.trips.get("trip1").unwrap().stop_times.len());
+/// # Ok::<(), gtfs_structures::error::Error>(())
+///```
+#[derive(Derivative)]
+#[derivative(Default)]
+pub struct GtfsReader {
+    /// [crate::objects::StopTime] are very large and not always needed. This allows to skip reading them
+    #[derivative(Default(value = "true"))]
+    pub read_stop_times: bool,
+}
+
+impl GtfsReader {
+    /// Configures the reader to not read the stop times
+    ///
+    /// This can be useful to save time and memory with large datasets when the timetable are not needed
+    /// Returns Self and can be chained
+    pub fn without_stop_times(&mut self) -> &mut Self {
+        self.read_stop_times = false;
+        self
+    }
+
+    /// Reads from an url (if starts with `"http"`), or a local path (either a directory or zipped file)
+    ///
+    /// To read from an url, build with read-url feature
+    /// See also [Gtfs::from_url] and [Gtfs::from_path] if you don’t want the library to guess
+    pub fn read(&self, gtfs: &str) -> Result<Gtfs, Error> {
+        RawGtfs::new_params(gtfs, self).and_then(Gtfs::try_from)
+    }
+
+    /// Reads the raw GTFS from a local zip archive or local directory
+    pub fn raw_from_path<P>(&self, path: P) -> Result<RawGtfs, Error>
+    where
+        P: AsRef<Path> + std::fmt::Display,
+    {
+        RawGtfs::from_path_params(path, self)
+    }
+
+    /// Reads the raw GTFS from a local zip archive or local directory
+    pub fn from_path<P>(&self, path: P) -> Result<Gtfs, Error>
+    where
+        P: AsRef<Path> + std::fmt::Display,
+    {
+        RawGtfs::from_path_params(path, self).and_then(Gtfs::try_from)
+    }
+
+    /// Reads the GTFS from a remote url
+    ///
+    /// The library must be built with the read-url feature
+    #[cfg(feature = "read-url")]
+    pub fn from_url<U: reqwest::IntoUrl>(&self, url: U) -> Result<Gtfs, Error> {
+        RawGtfs::from_url_params(url, self).and_then(Gtfs::try_from)
+    }
+
+    /// Asynchronously reads the GTFS from a remote url
+    ///
+    /// The library must be built with the read-url feature
+    #[cfg(feature = "read-url")]
+    pub async fn from_url_async<U: reqwest::IntoUrl>(&self, url: U) -> Result<Gtfs, Error> {
+        RawGtfs::from_url_async_params(url, self)
+            .await
+            .and_then(Gtfs::try_from)
+    }
+}

--- a/src/gtfs_reader.rs
+++ b/src/gtfs_reader.rs
@@ -136,14 +136,14 @@ impl RawGtfsReader {
         })
     }
 
-    /// Reads from an url (if starts with `"http"`), or a local path (either a directory or zipped file)
-    #[cfg(feature = "read-url")]
+    /// Reads from an url (if starts with `"http"`) if the feature `read-url` is activated,
+    /// or a local path (either a directory or zipped file)
     pub fn read(self, gtfs: &str) -> Result<RawGtfs, Error> {
+        #[cfg(feature = "read-url")]
         if gtfs.starts_with("http") {
-            self.read_from_url(gtfs)
-        } else {
-            self.read_from_path(gtfs)
+            return self.read_from_url(gtfs);
         }
+        self.read_from_path(gtfs)
     }
 
     /// Reads the GTFS from a remote url

--- a/src/gtfs_reader.rs
+++ b/src/gtfs_reader.rs
@@ -1,14 +1,32 @@
+use chrono::Utc;
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+
 use crate::{Error, Gtfs, RawGtfs};
+use std::collections::HashMap;
 use std::convert::TryFrom;
+use std::fs::File;
+use std::io::Read;
 use std::path::Path;
 
 /// Allows to parameterize how the parsing library behaves
 ///
 /// ```
 ///let gtfs = gtfs_structures::GtfsReader::default()
-///    .without_stop_times()
+///    .read_stop_times(false)
 ///    .read("fixtures/zips/gtfs.zip")?;
 ///assert_eq!(0, gtfs.trips.get("trip1").unwrap().stop_times.len());
+/// # Ok::<(), gtfs_structures::error::Error>(())
+///```
+///
+/// You can also get a [RawGtfs] by doing
+/// ```
+///let gtfs = gtfs_structures::GtfsReader::default()
+///    .read_stop_times(false)
+///    .raw()
+///    .read("fixtures/zips/gtfs.zip")?;
+///assert_eq!(1, gtfs.trips?.len());
+///assert_eq!(0, gtfs.stop_times?.len());
 /// # Ok::<(), gtfs_structures::error::Error>(())
 ///```
 #[derive(Derivative)]
@@ -20,12 +38,12 @@ pub struct GtfsReader {
 }
 
 impl GtfsReader {
-    /// Configures the reader to not read the stop times
+    /// Configures the reader to read or not the stop times (default: true)
     ///
     /// This can be useful to save time and memory with large datasets when the timetable are not needed
     /// Returns Self and can be chained
-    pub fn without_stop_times(&mut self) -> &mut Self {
-        self.read_stop_times = false;
+    pub fn read_stop_times(mut self, read_stop_times: bool) -> Self {
+        self.read_stop_times = read_stop_times;
         self
     }
 
@@ -33,41 +51,312 @@ impl GtfsReader {
     ///
     /// To read from an url, build with read-url feature
     /// See also [Gtfs::from_url] and [Gtfs::from_path] if you don’t want the library to guess
-    pub fn read(&self, gtfs: &str) -> Result<Gtfs, Error> {
-        RawGtfs::new_params(gtfs, self).and_then(Gtfs::try_from)
+    pub fn read(self, gtfs: &str) -> Result<Gtfs, Error> {
+        self.raw().read(gtfs).and_then(Gtfs::try_from)
     }
 
     /// Reads the raw GTFS from a local zip archive or local directory
-    pub fn raw_from_path<P>(&self, path: P) -> Result<RawGtfs, Error>
+    pub fn read_from_path<P>(self, path: P) -> Result<Gtfs, Error>
     where
         P: AsRef<Path> + std::fmt::Display,
     {
-        RawGtfs::from_path_params(path, self)
-    }
-
-    /// Reads the raw GTFS from a local zip archive or local directory
-    pub fn from_path<P>(&self, path: P) -> Result<Gtfs, Error>
-    where
-        P: AsRef<Path> + std::fmt::Display,
-    {
-        RawGtfs::from_path_params(path, self).and_then(Gtfs::try_from)
+        self.raw().read_from_path(path).and_then(Gtfs::try_from)
     }
 
     /// Reads the GTFS from a remote url
     ///
     /// The library must be built with the read-url feature
     #[cfg(feature = "read-url")]
-    pub fn from_url<U: reqwest::IntoUrl>(&self, url: U) -> Result<Gtfs, Error> {
-        RawGtfs::from_url_params(url, self).and_then(Gtfs::try_from)
+    pub fn read_from_url<U: reqwest::IntoUrl>(self, url: U) -> Result<Gtfs, Error> {
+        self.raw().read_from_url(url).and_then(Gtfs::try_from)
     }
 
     /// Asynchronously reads the GTFS from a remote url
     ///
     /// The library must be built with the read-url feature
     #[cfg(feature = "read-url")]
-    pub async fn from_url_async<U: reqwest::IntoUrl>(&self, url: U) -> Result<Gtfs, Error> {
-        RawGtfs::from_url_async_params(url, self)
+    pub async fn read_from_url_async<U: reqwest::IntoUrl>(self, url: U) -> Result<Gtfs, Error> {
+        self.raw()
+            .read_from_url_async(url)
             .await
             .and_then(Gtfs::try_from)
     }
+
+    /// Read the Gtfs as a [RawGtfs].
+    ///
+    /// ```
+    ///let gtfs = gtfs_structures::GtfsReader::default()
+    ///    .read_stop_times(false)
+    ///    .raw()
+    ///    .read("fixtures/zips/gtfs.zip")?;
+    ///assert_eq!(1, gtfs.trips?.len());
+    ///assert_eq!(0, gtfs.stop_times?.len());
+    /// # Ok::<(), gtfs_structures::error::Error>(())
+    ///```
+    pub fn raw(self) -> RawGtfsReader {
+        RawGtfsReader { reader: self }
+    }
+}
+
+/// This reader generates [RawGtfs]. It must be built using [GtfsReader::raw]
+///
+/// The methods to read a Gtfs are the same as for [GtfsReader]
+pub struct RawGtfsReader {
+    reader: GtfsReader,
+}
+
+impl RawGtfsReader {
+    fn read_from_directory(&self, p: &std::path::Path) -> Result<RawGtfs, Error> {
+        let now = Utc::now();
+        // Thoses files are not mandatory
+        // We use None if they don’t exist, not an Error
+        let files = std::fs::read_dir(p)?
+            .filter_map(|d| d.ok().and_then(|p| p.path().to_str().map(|s| s.to_owned())))
+            .collect();
+
+        Ok(RawGtfs {
+            trips: read_objs_from_path(p.join("trips.txt")),
+            calendar: read_objs_from_optional_path(&p, "calendar.txt"),
+            calendar_dates: read_objs_from_optional_path(&p, "calendar_dates.txt"),
+            stops: read_objs_from_path(p.join("stops.txt")),
+            routes: read_objs_from_path(p.join("routes.txt")),
+            stop_times: if self.reader.read_stop_times {
+                read_objs_from_path(p.join("stop_times.txt"))
+            } else {
+                Ok(Vec::new())
+            },
+            agencies: read_objs_from_path(p.join("agency.txt")),
+            shapes: read_objs_from_optional_path(&p, "shapes.txt"),
+            fare_attributes: read_objs_from_optional_path(&p, "fare_attributes.txt"),
+            frequencies: read_objs_from_optional_path(&p, "frequencies.txt"),
+            feed_info: read_objs_from_optional_path(&p, "feed_info.txt"),
+            read_duration: Utc::now().signed_duration_since(now).num_milliseconds(),
+            files,
+            sha256: None,
+        })
+    }
+
+    /// Reads from an url (if starts with `"http"`), or a local path (either a directory or zipped file)
+    #[cfg(feature = "read-url")]
+    pub fn read(self, gtfs: &str) -> Result<RawGtfs, Error> {
+        if gtfs.starts_with("http") {
+            self.read_from_url(gtfs)
+        } else {
+            self.read_from_path(gtfs)
+        }
+    }
+
+    /// Reads the GTFS from a remote url
+    #[cfg(feature = "read-url")]
+    pub fn read_from_url<U: reqwest::IntoUrl>(self, url: U) -> Result<RawGtfs, Error> {
+        let mut res = reqwest::blocking::get(url)?;
+        let mut body = Vec::new();
+        res.read_to_end(&mut body)?;
+        let cursor = std::io::Cursor::new(body);
+        self.read_from_reader(cursor)
+    }
+
+    /// Asynchronously reads the GTFS from a remote url
+    #[cfg(feature = "read-url")]
+    pub async fn read_from_url_async<U: reqwest::IntoUrl>(self, url: U) -> Result<RawGtfs, Error> {
+        let res = reqwest::get(url).await?.bytes().await?;
+        let reader = std::io::Cursor::new(res);
+        self.read_from_reader(reader)
+    }
+
+    /// Reads the raw GTFS from a local zip archive or local directory
+    pub fn read_from_path<P>(&self, path: P) -> Result<RawGtfs, Error>
+    where
+        P: AsRef<Path> + std::fmt::Display,
+    {
+        let p = path.as_ref();
+        if p.is_file() {
+            let reader = File::open(p)?;
+            self.read_from_reader(reader)
+        } else if p.is_dir() {
+            self.read_from_directory(p)
+        } else {
+            Err(Error::NotFileNorDirectory(format!("{}", p.display())))
+        }
+    }
+
+    pub fn read_from_reader<T: std::io::Read + std::io::Seek>(
+        &self,
+        reader: T,
+    ) -> Result<RawGtfs, Error> {
+        let now = Utc::now();
+        let mut hasher = Sha256::new();
+        let mut buf_reader = std::io::BufReader::new(reader);
+        let _n = std::io::copy(&mut buf_reader, &mut hasher)?;
+        let hash = hasher.finalize();
+        let mut archive = zip::ZipArchive::new(buf_reader)?;
+        let mut file_mapping = HashMap::new();
+        let mut files = Vec::new();
+
+        for i in 0..archive.len() {
+            let archive_file = archive.by_index(i)?;
+            files.push(archive_file.name().to_owned());
+
+            for gtfs_file in &[
+                "agency.txt",
+                "calendar.txt",
+                "calendar_dates.txt",
+                "routes.txt",
+                "stops.txt",
+                "stop_times.txt",
+                "trips.txt",
+                "fare_attributes.txt",
+                "frequencies.txt",
+                "feed_info.txt",
+                "shapes.txt",
+            ] {
+                let path = std::path::Path::new(archive_file.name());
+                if path.file_name() == Some(std::ffi::OsStr::new(gtfs_file)) {
+                    file_mapping.insert(gtfs_file, i);
+                    break;
+                }
+            }
+        }
+
+        Ok(RawGtfs {
+            agencies: read_file(&file_mapping, &mut archive, "agency.txt"),
+            calendar: read_optional_file(&file_mapping, &mut archive, "calendar.txt"),
+            calendar_dates: read_optional_file(&file_mapping, &mut archive, "calendar_dates.txt"),
+            routes: read_file(&file_mapping, &mut archive, "routes.txt"),
+            stops: read_file(&file_mapping, &mut archive, "stops.txt"),
+            stop_times: if self.reader.read_stop_times {
+                read_file(&file_mapping, &mut archive, "stop_times.txt")
+            } else {
+                Ok(Vec::new())
+            },
+            trips: read_file(&file_mapping, &mut archive, "trips.txt"),
+            fare_attributes: read_optional_file(&file_mapping, &mut archive, "fare_attributes.txt"),
+            frequencies: read_optional_file(&file_mapping, &mut archive, "frequencies.txt"),
+            feed_info: read_optional_file(&file_mapping, &mut archive, "feed_info.txt"),
+            shapes: read_optional_file(&file_mapping, &mut archive, "shapes.txt"),
+            read_duration: Utc::now().signed_duration_since(now).num_milliseconds(),
+            files,
+            sha256: Some(format!("{:x}", hash)),
+        })
+    }
+}
+
+fn read_objs<T, O>(mut reader: T, file_name: &str) -> Result<Vec<O>, Error>
+where
+    for<'de> O: Deserialize<'de>,
+    T: std::io::Read,
+{
+    let mut bom = [0; 3];
+    reader
+        .read_exact(&mut bom)
+        .map_err(|e| Error::NamedFileIO {
+            file_name: file_name.to_owned(),
+            source: Box::new(e),
+        })?;
+
+    let chained = if bom != [0xefu8, 0xbbu8, 0xbfu8] {
+        bom.chain(reader)
+    } else {
+        [].chain(reader)
+    };
+
+    let mut reader = csv::ReaderBuilder::new()
+        .flexible(true)
+        .trim(csv::Trim::Fields)
+        .from_reader(chained);
+    // We store the headers to be able to return them in case of errors
+    let headers = reader
+        .headers()
+        .map_err(|e| Error::CSVError {
+            file_name: file_name.to_owned(),
+            source: e,
+            line_in_error: None,
+        })?
+        .clone();
+
+    let mut res = Vec::new();
+    for rec in reader.records() {
+        let r = rec.map_err(|e| Error::CSVError {
+            file_name: file_name.to_owned(),
+            source: e,
+            line_in_error: None,
+        })?;
+        let o = r.deserialize(Some(&headers)).map_err(|e| Error::CSVError {
+            file_name: file_name.to_owned(),
+            source: e,
+            line_in_error: Some(crate::error::LineError {
+                headers: headers.into_iter().map(|s| s.to_owned()).collect(),
+                values: r.into_iter().map(|s| s.to_owned()).collect(),
+            }),
+        })?;
+        res.push(o);
+    }
+
+    Ok(res)
+}
+
+fn read_objs_from_path<O>(path: std::path::PathBuf) -> Result<Vec<O>, Error>
+where
+    for<'de> O: Deserialize<'de>,
+{
+    let file_name = path
+        .file_name()
+        .and_then(|f| f.to_str())
+        .unwrap_or("invalid_file_name")
+        .to_string();
+    if path.exists() {
+        File::open(path)
+            .map_err(|e| Error::NamedFileIO {
+                file_name: file_name.to_owned(),
+                source: Box::new(e),
+            })
+            .and_then(|r| read_objs(r, &file_name))
+    } else {
+        Err(Error::MissingFile(file_name))
+    }
+}
+
+fn read_objs_from_optional_path<O>(
+    dir_path: &std::path::Path,
+    file_name: &str,
+) -> Option<Result<Vec<O>, Error>>
+where
+    for<'de> O: Deserialize<'de>,
+{
+    File::open(dir_path.join(file_name))
+        .ok()
+        .map(|r| read_objs(r, file_name))
+}
+
+fn read_file<O, T>(
+    file_mapping: &HashMap<&&str, usize>,
+    archive: &mut zip::ZipArchive<T>,
+    file_name: &str,
+) -> Result<Vec<O>, Error>
+where
+    for<'de> O: Deserialize<'de>,
+    T: std::io::Read + std::io::Seek,
+{
+    read_optional_file(file_mapping, archive, file_name)
+        .unwrap_or_else(|| Err(Error::MissingFile(file_name.to_owned())))
+}
+
+fn read_optional_file<O, T>(
+    file_mapping: &HashMap<&&str, usize>,
+    archive: &mut zip::ZipArchive<T>,
+    file_name: &str,
+) -> Option<Result<Vec<O>, Error>>
+where
+    for<'de> O: Deserialize<'de>,
+    T: std::io::Read + std::io::Seek,
+{
+    file_mapping.get(&file_name).map(|i| {
+        read_objs(
+            archive.by_index(*i).map_err(|e| Error::NamedFileIO {
+                file_name: file_name.to_owned(),
+                source: Box::new(e),
+            })?,
+            file_name,
+        )
+    })
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,7 @@ extern crate serde_derive;
 
 pub mod error;
 mod gtfs;
+mod gtfs_reader;
 pub(crate) mod objects;
 mod raw_gtfs;
 
@@ -53,5 +54,6 @@ mod tests;
 
 pub use error::Error;
 pub use gtfs::Gtfs;
+pub use gtfs_reader::GtfsReader;
 pub use objects::*;
 pub use raw_gtfs::RawGtfs;

--- a/src/raw_gtfs.rs
+++ b/src/raw_gtfs.rs
@@ -62,12 +62,6 @@ impl RawGtfs {
     ///
     /// To read from an url, build with read-url feature
     /// See also [RawGtfs::from_url] and [RawGtfs::from_path] if you don’t want the library to guess
-    #[cfg(feature = "read-url")]
-    pub fn new(gtfs: &str) -> Result<Self, Error> {
-        GtfsReader::default().raw().read(gtfs)
-    }
-
-    #[cfg(not(feature = "read-url"))]
     pub fn new(gtfs: &str) -> Result<Self, Error> {
         GtfsReader::default().raw().read(gtfs)
     }

--- a/src/raw_gtfs.rs
+++ b/src/raw_gtfs.rs
@@ -1,13 +1,6 @@
 use crate::objects::*;
 use crate::Error;
 use crate::GtfsReader;
-use chrono::Utc;
-use serde::Deserialize;
-use sha2::digest::Digest;
-use sha2::Sha256;
-use std::collections::HashMap;
-use std::fs::File;
-use std::io::Read;
 use std::path::Path;
 
 /// Data structure that map the GTFS csv with little intelligence
@@ -46,140 +39,6 @@ pub struct RawGtfs {
     pub sha256: Option<String>,
 }
 
-fn read_objs<T, O>(mut reader: T, file_name: &str) -> Result<Vec<O>, Error>
-where
-    for<'de> O: Deserialize<'de>,
-    T: std::io::Read,
-{
-    let mut bom = [0; 3];
-    reader
-        .read_exact(&mut bom)
-        .map_err(|e| Error::NamedFileIO {
-            file_name: file_name.to_owned(),
-            source: Box::new(e),
-        })?;
-
-    let chained = if bom != [0xefu8, 0xbbu8, 0xbfu8] {
-        bom.chain(reader)
-    } else {
-        [].chain(reader)
-    };
-
-    let mut reader = csv::ReaderBuilder::new()
-        .flexible(true)
-        .trim(csv::Trim::Fields)
-        .from_reader(chained);
-    // We store the headers to be able to return them in case of errors
-    let headers = reader
-        .headers()
-        .map_err(|e| Error::CSVError {
-            file_name: file_name.to_owned(),
-            source: e,
-            line_in_error: None,
-        })?
-        .clone();
-
-    let mut res = Vec::new();
-    for rec in reader.records() {
-        let r = rec.map_err(|e| Error::CSVError {
-            file_name: file_name.to_owned(),
-            source: e,
-            line_in_error: None,
-        })?;
-        let o = r.deserialize(Some(&headers)).map_err(|e| Error::CSVError {
-            file_name: file_name.to_owned(),
-            source: e,
-            line_in_error: Some(crate::error::LineError {
-                headers: headers.into_iter().map(|s| s.to_owned()).collect(),
-                values: r.into_iter().map(|s| s.to_owned()).collect(),
-            }),
-        })?;
-        res.push(o);
-    }
-
-    Ok(res)
-}
-
-fn read_objs_from_path<O>(path: std::path::PathBuf) -> Result<Vec<O>, Error>
-where
-    for<'de> O: Deserialize<'de>,
-{
-    let file_name = path
-        .file_name()
-        .and_then(|f| f.to_str())
-        .unwrap_or("invalid_file_name")
-        .to_string();
-    if path.exists() {
-        File::open(path)
-            .map_err(|e| Error::NamedFileIO {
-                file_name: file_name.to_owned(),
-                source: Box::new(e),
-            })
-            .and_then(|r| read_objs(r, &file_name))
-    } else {
-        Err(Error::MissingFile(file_name))
-    }
-}
-
-fn read_objs_from_optional_path<O>(
-    dir_path: &std::path::Path,
-    file_name: &str,
-) -> Option<Result<Vec<O>, Error>>
-where
-    for<'de> O: Deserialize<'de>,
-{
-    File::open(dir_path.join(file_name))
-        .ok()
-        .map(|r| read_objs(r, file_name))
-}
-
-fn read_file<O, T>(
-    file_mapping: &HashMap<&&str, usize>,
-    archive: &mut zip::ZipArchive<T>,
-    file_name: &str,
-) -> Result<Vec<O>, Error>
-where
-    for<'de> O: Deserialize<'de>,
-    T: std::io::Read + std::io::Seek,
-{
-    read_optional_file(file_mapping, archive, file_name)
-        .unwrap_or_else(|| Err(Error::MissingFile(file_name.to_owned())))
-}
-
-fn read_optional_file<O, T>(
-    file_mapping: &HashMap<&&str, usize>,
-    archive: &mut zip::ZipArchive<T>,
-    file_name: &str,
-) -> Option<Result<Vec<O>, Error>>
-where
-    for<'de> O: Deserialize<'de>,
-    T: std::io::Read + std::io::Seek,
-{
-    file_mapping.get(&file_name).map(|i| {
-        read_objs(
-            archive.by_index(*i).map_err(|e| Error::NamedFileIO {
-                file_name: file_name.to_owned(),
-                source: Box::new(e),
-            })?,
-            file_name,
-        )
-    })
-}
-
-fn mandatory_file_summary<T>(objs: &Result<Vec<T>, Error>) -> String {
-    match objs {
-        Ok(vec) => format!("{} objects", vec.len()),
-        Err(e) => format!("Could not read {}", e),
-    }
-}
-
-fn optional_file_summary<T>(objs: &Option<Result<Vec<T>, Error>>) -> String {
-    match objs {
-        Some(objs) => mandatory_file_summary(objs),
-        None => "File not present".to_string(),
-    }
-}
-
 impl RawGtfs {
     /// Prints on stdout some basic statistics about the GTFS file (numbers of elements for each object). Mostly to be sure that everything was read
     pub fn print_stats(&self) {
@@ -205,21 +64,12 @@ impl RawGtfs {
     /// See also [RawGtfs::from_url] and [RawGtfs::from_path] if you don’t want the library to guess
     #[cfg(feature = "read-url")]
     pub fn new(gtfs: &str) -> Result<Self, Error> {
-        Self::new_params(gtfs, &GtfsReader::default())
+        GtfsReader::default().raw().read(gtfs)
     }
 
     #[cfg(not(feature = "read-url"))]
-    pub fn new(gtfs_source: &str) -> Result<Self, Error> {
-        Self::from_path(gtfs_source)
-    }
-
-    #[cfg(feature = "read-url")]
-    pub(crate) fn new_params(gtfs: &str, params: &GtfsReader) -> Result<Self, Error> {
-        if gtfs.starts_with("http") {
-            Self::from_url_params(gtfs, params)
-        } else {
-            Self::from_path_params(gtfs, params)
-        }
+    pub fn new(gtfs: &str) -> Result<Self, Error> {
+        GtfsReader::default().raw().read(gtfs)
     }
 
     /// Reads the raw GTFS from a local zip archive or local directory
@@ -227,52 +77,7 @@ impl RawGtfs {
     where
         P: AsRef<Path> + std::fmt::Display,
     {
-        Self::from_path_params(path, &GtfsReader::default())
-    }
-
-    pub(crate) fn from_path_params<P>(path: P, params: &GtfsReader) -> Result<Self, Error>
-    where
-        P: AsRef<Path> + std::fmt::Display,
-    {
-        let p = path.as_ref();
-        if p.is_file() {
-            let reader = File::open(p)?;
-            Self::from_reader_params(reader, params)
-        } else if p.is_dir() {
-            Self::from_directory(p, params)
-        } else {
-            Err(Error::NotFileNorDirectory(format!("{}", p.display())))
-        }
-    }
-
-    fn from_directory(p: &std::path::Path, params: &GtfsReader) -> Result<Self, Error> {
-        let now = Utc::now();
-        // Thoses files are not mandatory
-        // We use None if they don’t exist, not an Error
-        let files = std::fs::read_dir(p)?
-            .filter_map(|d| d.ok().and_then(|p| p.path().to_str().map(|s| s.to_owned())))
-            .collect();
-
-        Ok(Self {
-            trips: read_objs_from_path(p.join("trips.txt")),
-            calendar: read_objs_from_optional_path(&p, "calendar.txt"),
-            calendar_dates: read_objs_from_optional_path(&p, "calendar_dates.txt"),
-            stops: read_objs_from_path(p.join("stops.txt")),
-            routes: read_objs_from_path(p.join("routes.txt")),
-            stop_times: if params.read_stop_times {
-                read_objs_from_path(p.join("stop_times.txt"))
-            } else {
-                Ok(Vec::new())
-            },
-            agencies: read_objs_from_path(p.join("agency.txt")),
-            shapes: read_objs_from_optional_path(&p, "shapes.txt"),
-            fare_attributes: read_objs_from_optional_path(&p, "fare_attributes.txt"),
-            frequencies: read_objs_from_optional_path(&p, "frequencies.txt"),
-            feed_info: read_objs_from_optional_path(&p, "feed_info.txt"),
-            read_duration: Utc::now().signed_duration_since(now).num_milliseconds(),
-            files,
-            sha256: None,
-        })
+        GtfsReader::default().raw().read_from_path(path)
     }
 
     /// Reads the raw GTFS from a remote url
@@ -280,19 +85,7 @@ impl RawGtfs {
     /// The library must be built with the read-url feature
     #[cfg(feature = "read-url")]
     pub fn from_url<U: reqwest::IntoUrl>(url: U) -> Result<Self, Error> {
-        Self::from_url_params(url, &GtfsReader::default())
-    }
-
-    #[cfg(feature = "read-url")]
-    pub(crate) fn from_url_params<U: reqwest::IntoUrl>(
-        url: U,
-        params: &GtfsReader,
-    ) -> Result<Self, Error> {
-        let mut res = reqwest::blocking::get(url)?;
-        let mut body = Vec::new();
-        res.read_to_end(&mut body)?;
-        let cursor = std::io::Cursor::new(body);
-        Self::from_reader_params(cursor, params)
+        GtfsReader::default().raw().read_from_url(url)
     }
 
     /// Non-blocking read the raw GTFS from a remote url
@@ -300,84 +93,27 @@ impl RawGtfs {
     /// The library must be built with the read-url feature
     #[cfg(feature = "read-url")]
     pub async fn from_url_async<U: reqwest::IntoUrl>(url: U) -> Result<Self, Error> {
-        Self::from_url_async_params(url, &GtfsReader::default()).await
-    }
-
-    #[cfg(feature = "read-url")]
-    pub(crate) async fn from_url_async_params<U: reqwest::IntoUrl>(
-        url: U,
-        params: &GtfsReader,
-    ) -> Result<Self, Error> {
-        let res = reqwest::get(url).await?.bytes().await?;
-
-        let reader = std::io::Cursor::new(res);
-        Self::from_reader_params(reader, params)
+        GtfsReader::default().raw().read_from_url_async(url).await
     }
 
     /// Reads for any object implementing [std::io::Read] and [std::io::Seek]
     ///
     /// Mostly an internal function that abstracts reading from an url or local file
     pub fn from_reader<T: std::io::Read + std::io::Seek>(reader: T) -> Result<Self, Error> {
-        Self::from_reader_params(reader, &GtfsReader::default())
+        GtfsReader::default().raw().read_from_reader(reader)
     }
+}
 
-    pub(crate) fn from_reader_params<T: std::io::Read + std::io::Seek>(
-        reader: T,
-        params: &GtfsReader,
-    ) -> Result<Self, Error> {
-        let now = Utc::now();
-        let mut hasher = Sha256::new();
-        let mut buf_reader = std::io::BufReader::new(reader);
-        let _n = std::io::copy(&mut buf_reader, &mut hasher)?;
-        let hash = hasher.finalize();
-        let mut archive = zip::ZipArchive::new(buf_reader)?;
-        let mut file_mapping = HashMap::new();
-        let mut files = Vec::new();
+fn mandatory_file_summary<T>(objs: &Result<Vec<T>, Error>) -> String {
+    match objs {
+        Ok(vec) => format!("{} objects", vec.len()),
+        Err(e) => format!("Could not read {}", e),
+    }
+}
 
-        for i in 0..archive.len() {
-            let archive_file = archive.by_index(i)?;
-            files.push(archive_file.name().to_owned());
-
-            for gtfs_file in &[
-                "agency.txt",
-                "calendar.txt",
-                "calendar_dates.txt",
-                "routes.txt",
-                "stops.txt",
-                "stop_times.txt",
-                "trips.txt",
-                "fare_attributes.txt",
-                "frequencies.txt",
-                "feed_info.txt",
-                "shapes.txt",
-            ] {
-                let path = std::path::Path::new(archive_file.name());
-                if path.file_name() == Some(std::ffi::OsStr::new(gtfs_file)) {
-                    file_mapping.insert(gtfs_file, i);
-                    break;
-                }
-            }
-        }
-
-        Ok(Self {
-            agencies: read_file(&file_mapping, &mut archive, "agency.txt"),
-            calendar: read_optional_file(&file_mapping, &mut archive, "calendar.txt"),
-            calendar_dates: read_optional_file(&file_mapping, &mut archive, "calendar_dates.txt"),
-            routes: read_file(&file_mapping, &mut archive, "routes.txt"),
-            stops: read_file(&file_mapping, &mut archive, "stops.txt"),
-            stop_times: if params.read_stop_times {
-                read_file(&file_mapping, &mut archive, "stop_times.txt")
-            } else {
-                Ok(Vec::new())
-            },
-            trips: read_file(&file_mapping, &mut archive, "trips.txt"),
-            fare_attributes: read_optional_file(&file_mapping, &mut archive, "fare_attributes.txt"),
-            frequencies: read_optional_file(&file_mapping, &mut archive, "frequencies.txt"),
-            feed_info: read_optional_file(&file_mapping, &mut archive, "feed_info.txt"),
-            shapes: read_optional_file(&file_mapping, &mut archive, "shapes.txt"),
-            read_duration: Utc::now().signed_duration_since(now).num_milliseconds(),
-            files,
-            sha256: Some(format!("{:x}", hash)),
-        })
+fn optional_file_summary<T>(objs: &Option<Result<Vec<T>, Error>>) -> String {
+    match objs {
+        Some(objs) => mandatory_file_summary(objs),
+        None => "File not present".to_string(),
     }
 }


### PR DESCRIPTION
I’m not really sure about this approach. It is quite verbose and duplicates a shitton of functions. Could we imagine something template based? Or maybe put the parameters on the basic functions and make a breaking change?

However, like this, we can easilly add a parameter like `trim` 

Closes #65 