### PR TITLE
Make (continuous) pickup drop off non-optional / allow parsing invalid values

### DIFF
--- a/fixtures/basic/stop_times.txt
+++ b/fixtures/basic/stop_times.txt
@@ -1,3 +1,4 @@
 trip_id,arrival_time,departure_time,stop_id,stop_sequence,stop_time_desc,pickup_type,drop_off_type,timepoint
 trip1,14:00:00,14:00:00,stop2,0,"",0,1,""
 trip1,15:00:00,15:00:00,stop3,0,"",2,,"0"
+trip1,16:00:00,16:00:00,stop4,2,"",2,-999,

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -153,43 +153,67 @@ impl Serialize for RouteType {
 }
 
 /// Describes if and how a traveller can board or alight the vehicle. See <https://gtfs.org/reference/static/#stop_timestxt> `pickup_type` and `dropoff_type`
-#[derive(Debug, Derivative, Serialize, Deserialize, Copy, Clone, PartialEq)]
+#[derive(Debug, Derivative, Serialize, Copy, Clone, PartialEq)]
 #[derivative(Default(bound = ""))]
 pub enum PickupDropOffType {
-    /// The vehicle always stop for pickup or drop off
+    /// Regularly scheduled pickup or drop off (default when empty).
     #[derivative(Default)]
-    #[serde(rename = "0")]
-    Regular,
-    /// Impossible to pickup or drop off at that stop
-    #[serde(rename = "1")]
-    NotAvailable,
-    /// Must phone agency to arrange pickup or drop off
-    #[serde(rename = "2")]
-    ArrangeByPhone,
-    /// Must coordinate with driver to arrange pickup or drop off
-    #[serde(rename = "3")]
-    CoordinateWithDriver,
+    Regular = 0,
+    /// No pickup or drop off available.
+    NotAvailable = 1,
+    /// Must phone agency to arrange pickup or drop off.
+    ArrangeByPhone = 2,
+    /// Must coordinate with driver to arrange pickup or drop off.
+    CoordinateWithDriver = 3,
+}
+
+impl<'de> Deserialize<'de> for PickupDropOffType {
+    fn deserialize<D>(deserializer: D) -> Result<PickupDropOffType, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s: String = String::deserialize(deserializer)?;
+        Ok(match s.as_str() {
+            "0" => PickupDropOffType::Regular,
+            "1" => PickupDropOffType::NotAvailable,
+            "2" => PickupDropOffType::ArrangeByPhone,
+            "3" => PickupDropOffType::CoordinateWithDriver,
+            _ => PickupDropOffType::Regular,
+        })
+    }
 }
 
 /// Indicates whether a rider can board the transit vehicle anywhere along the vehicle’s travel path
 ///
 /// Those values are only defined on <https://developers.google.com/transit/gtfs/reference#routestxt,> not on <https://gtfs.org/reference/static/#routestxt>
-#[derive(Debug, Derivative, Serialize, Deserialize, Copy, Clone, PartialEq)]
+#[derive(Debug, Derivative, Serialize, Copy, Clone, PartialEq)]
 #[derivative(Default(bound = ""))]
 pub enum ContinuousPickupDropOff {
-    /// Continuous stopping pickup or drop off
-    #[serde(rename = "0")]
-    Continuous,
-    /// No continuous stopping pickup or drop off
+    /// Continuous stopping pickup or drop off.
+    Continuous = 0,
+    /// No continuous stopping pickup or drop off (default when empty).
     #[derivative(Default)]
-    #[serde(rename = "1")]
-    NotAvailable,
-    /// Must phone an agency to arrange continuous stopping pickup or drop off
-    #[serde(rename = "2")]
-    ArrangeByPhone,
-    /// Must coordinate with a driver to arrange continuous stopping pickup or drop off
-    #[serde(rename = "3")]
-    CoordinateWithDriver,
+    NotAvailable = 1,
+    /// Must phone agency to arrange continuous stopping pickup or drop off.
+    ArrangeByPhone = 2,
+    /// Must coordinate with driver to arrange continuous stopping pickup or drop off.
+    CoordinateWithDriver = 3,
+}
+
+impl<'de> Deserialize<'de> for ContinuousPickupDropOff {
+    fn deserialize<D>(deserializer: D) -> Result<ContinuousPickupDropOff, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s: String = String::deserialize(deserializer)?;
+        Ok(match s.as_str() {
+            "0" => ContinuousPickupDropOff::Continuous,
+            "1" => ContinuousPickupDropOff::NotAvailable,
+            "2" => ContinuousPickupDropOff::ArrangeByPhone,
+            "3" => ContinuousPickupDropOff::CoordinateWithDriver,
+            _ => ContinuousPickupDropOff::NotAvailable,
+        })
+    }
 }
 
 /// Describes if the stop time is exact or not. See <https://gtfs.org/reference/static/#stop_timestxt> `timepoint`
@@ -449,13 +473,17 @@ pub struct RawStopTime {
     /// Text that appears on signage identifying the trip's destination to riders
     pub stop_headsign: Option<String>,
     /// Indicates pickup method
-    pub pickup_type: Option<PickupDropOffType>,
+    #[serde(default)]
+    pub pickup_type: PickupDropOffType,
     /// Indicates drop off method
-    pub drop_off_type: Option<PickupDropOffType>,
+    #[serde(default)]
+    pub drop_off_type: PickupDropOffType,
     /// Indicates whether a rider can board the transit vehicle anywhere along the vehicle’s travel path
-    pub continuous_pickup: Option<ContinuousPickupDropOff>,
+    #[serde(default)]
+    pub continuous_pickup: ContinuousPickupDropOff,
     /// Indicates whether a rider can alight from the transit vehicle at any point along the vehicle’s travel path
-    pub continuous_drop_off: Option<ContinuousPickupDropOff>,
+    #[serde(default)]
+    pub continuous_drop_off: ContinuousPickupDropOff,
     /// Actual distance traveled along the associated shape, from the first stop to the stop specified in this record. This field specifies how much of the shape to draw between any two stops during a trip
     pub shape_dist_traveled: Option<f32>,
     /// Indicates if arrival and departure times for a stop are strictly adhered to by the vehicle or if they are instead approximate and/or interpolated times
@@ -477,17 +505,17 @@ pub struct StopTime {
     /// and this departure needs to be interpolated
     pub departure_time: Option<u32>,
     /// Indicates pickup method
-    pub pickup_type: Option<PickupDropOffType>,
+    pub pickup_type: PickupDropOffType,
     /// Indicates drop off method
-    pub drop_off_type: Option<PickupDropOffType>,
+    pub drop_off_type: PickupDropOffType,
     /// Order of stops for a particular trip. The values must increase along the trip but do not need to be consecutive
     pub stop_sequence: u16,
     /// Text that appears on signage identifying the trip's destination to riders
     pub stop_headsign: Option<String>,
     /// Indicates whether a rider can board the transit vehicle anywhere along the vehicle’s travel path
-    pub continuous_pickup: Option<ContinuousPickupDropOff>,
+    pub continuous_pickup: ContinuousPickupDropOff,
     /// Indicates whether a rider can alight from the transit vehicle at any point along the vehicle’s travel path
-    pub continuous_drop_off: Option<ContinuousPickupDropOff>,
+    pub continuous_drop_off: ContinuousPickupDropOff,
     /// Actual distance traveled along the associated shape, from the first stop to the stop specified in this record. This field specifies how much of the shape to draw between any two stops during a trip
     pub shape_dist_traveled: Option<f32>,
     /// Indicates if arrival and departure times for a stop are strictly adhered to by the vehicle or if they are instead approximate and/or interpolated times
@@ -553,9 +581,11 @@ pub struct Route {
     )]
     pub route_text_color: Option<RGB8>,
     /// Indicates whether a rider can board the transit vehicle anywhere along the vehicle’s travel path
-    pub continuous_pickup: Option<ContinuousPickupDropOff>,
+    #[serde(default)]
+    pub continuous_pickup: ContinuousPickupDropOff,
     /// Indicates whether a rider can alight from the transit vehicle at any point along the vehicle’s travel path
-    pub continuous_drop_off: Option<ContinuousPickupDropOff>,
+    #[serde(default)]
+    pub continuous_drop_off: ContinuousPickupDropOff,
 }
 
 impl Type for Route {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -80,20 +80,27 @@ fn read_trips() {
 fn read_stop_times() {
     let gtfs = Gtfs::from_path("fixtures/basic").expect("impossible to read gtfs");
     let stop_times = &gtfs.trips.get("trip1").unwrap().stop_times;
-    assert_eq!(2, stop_times.len());
+    assert_eq!(3, stop_times.len());
     assert_eq!(
         PickupDropOffType::Regular,
-        stop_times[0].pickup_type.unwrap()
+        stop_times[0].pickup_type
     );
     assert_eq!(
         PickupDropOffType::NotAvailable,
-        stop_times[0].drop_off_type.unwrap()
+        stop_times[0].drop_off_type
     );
     assert_eq!(
         PickupDropOffType::ArrangeByPhone,
-        stop_times[1].pickup_type.unwrap()
+        stop_times[1].pickup_type
     );
-    assert_eq!(None, stop_times[1].drop_off_type);
+    assert_eq!(
+        PickupDropOffType::Regular,
+        stop_times[1].drop_off_type
+    );
+    assert_eq!(
+        PickupDropOffType::Regular,
+        stop_times[2].drop_off_type
+    );
     assert_eq!(TimepointType::Exact, stop_times[0].timepoint);
     assert_eq!(TimepointType::Approximate, stop_times[1].timepoint);
 }


### PR DESCRIPTION
This brings `PickupDropOffType` and `ContinuousPickupDropOff` in line with other optional enums with default values like `LocationType`. The GTFS specification makes (continuous) pickup/drop off optional, but assigns a default value on empty, so the `Option` type is misleading: e.g. `None` for `pickup_type` means the same as `Some(PickupDropOffType::Regular)`. 

That's why I removed the `Option`s on `pickup_type`, `drop_off_type`, `continuous_pickup` and `continuous_drop_off`. This might be a backwards incompatible change.

Additionally, this change allows parsing invalid values for the (continuous) pickup / drop off columns (e.g. "-999", hello again [MTA Brooklyn GTFS](https://transitfeeds.com/p/mta/80/20210315/file/stop_times.txt)) and returning the default value instead.