### PR TITLE
Performance improvement

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Read GTFS (public transit timetables) files"
 name = "gtfs-structures"
-version = "0.29.2"
+version = "0.30.0"
 authors = ["Tristram Gräbener <tristramg@gmail.com>", "Antoine Desbordes <antoine.desbordes@gmail.com>"]
 repository = "https://github.com/rust-transit/gtfs-structure"
 license = "MIT"

--- a/src/gtfs_reader.rs
+++ b/src/gtfs_reader.rs
@@ -39,6 +39,12 @@ pub struct GtfsReader {
     /// If a an enumeration has un unknown value, should we use the default value
     #[derivative(Default(value = "false"))]
     pub unkown_enum_as_default: bool,
+    /// Avoid trimming the fields
+    ///
+    /// It is quite time consumming
+    /// If performance is an issue, and if your data is high quality, you can switch it off
+    #[derivative(Default(value = "true"))]
+    pub trim_fields: bool,
 }
 
 impl GtfsReader {
@@ -59,6 +65,15 @@ impl GtfsReader {
     /// Returns Self and can be chained
     pub fn unkown_enum_as_default(mut self, unkown_enum_as_default: bool) -> Self {
         self.unkown_enum_as_default = unkown_enum_as_default;
+        self
+    }
+
+    /// Should the fields be trimmed (default: true)
+    ///
+    /// It is quite time consumming
+    /// If performance is an issue, and if your data is high quality, you can set it to false
+    pub fn trim_fields(mut self, trim_fields: bool) -> Self {
+        self.trim_fields = trim_fields;
         self
     }
 
@@ -294,7 +309,11 @@ impl RawGtfsReader {
 
         let mut reader = csv::ReaderBuilder::new()
             .flexible(true)
-            .trim(csv::Trim::Fields)
+            .trim(if self.reader.trim_fields {
+                csv::Trim::Fields
+            } else {
+                csv::Trim::None
+            })
             .from_reader(chained);
         // We store the headers to be able to return them in case of errors
         let headers = reader

--- a/src/serde_helpers.rs
+++ b/src/serde_helpers.rs
@@ -92,7 +92,7 @@ where
 
     match s {
         None => Ok(None),
-        Some(t) => parse_time(&t).map(Some).map_err(de::Error::custom),
+        Some(t) => parse_time(t).map(Some).map_err(de::Error::custom),
     }
 }
 

--- a/src/serde_helpers.rs
+++ b/src/serde_helpers.rs
@@ -41,19 +41,23 @@ where
     }
 }
 
-pub fn parse_time_impl(v: Vec<&str>) -> Result<u32, std::num::ParseIntError> {
-    let hours: u32 = v[0].parse()?;
-    let minutes: u32 = v[1].parse()?;
-    let seconds: u32 = v[2].parse()?;
+pub fn parse_time_impl(h: &str, m: &str, s: &str) -> Result<u32, std::num::ParseIntError> {
+    let hours: u32 = h.parse()?;
+    let minutes: u32 = m.parse()?;
+    let seconds: u32 = s.parse()?;
     Ok(hours * 3600 + minutes * 60 + seconds)
 }
 
 pub fn parse_time(s: &str) -> Result<u32, crate::Error> {
-    let v: Vec<&str> = s.trim_start().split(':').collect();
-    if v.len() != 3 {
+    let len = s.len();
+
+    if s.len() < 7 || s.len() > 8 {
         Err(crate::Error::InvalidTime(s.to_owned()))
     } else {
-        parse_time_impl(v).map_err(|_| crate::Error::InvalidTime(s.to_owned()))
+        let sec = &s[len - 2..];
+        let min = &s[len - 5..len - 3];
+        let hour = &s[..len - 6];
+        parse_time_impl(hour, min, sec).map_err(|_| crate::Error::InvalidTime(s.to_owned()))
     }
 }
 

--- a/src/serde_helpers.rs
+++ b/src/serde_helpers.rs
@@ -7,8 +7,8 @@ pub fn deserialize_date<'de, D>(deserializer: D) -> Result<NaiveDate, D::Error>
 where
     D: Deserializer<'de>,
 {
-    let s = String::deserialize(deserializer)?;
-    NaiveDate::parse_from_str(&s, "%Y%m%d").map_err(serde::de::Error::custom)
+    let s: &str = Deserialize::deserialize(deserializer)?;
+    NaiveDate::parse_from_str(s, "%Y%m%d").map_err(serde::de::Error::custom)
 }
 
 pub fn serialize_date<S>(date: &NaiveDate, serializer: S) -> Result<S::Ok, S::Error>
@@ -22,8 +22,8 @@ pub fn deserialize_option_date<'de, D>(deserializer: D) -> Result<Option<NaiveDa
 where
     D: Deserializer<'de>,
 {
-    let s = Option::<String>::deserialize(deserializer)?
-        .map(|s| NaiveDate::parse_from_str(&s, "%Y%m%d").map_err(serde::de::Error::custom));
+    let s = Option::<&str>::deserialize(deserializer)?
+        .map(|s| NaiveDate::parse_from_str(s, "%Y%m%d").map_err(serde::de::Error::custom));
     match s {
         Some(Ok(s)) => Ok(Some(s)),
         Some(Err(e)) => Err(e),
@@ -169,8 +169,8 @@ pub fn deserialize_bool<'de, D>(deserializer: D) -> Result<bool, D::Error>
 where
     D: Deserializer<'de>,
 {
-    let s = String::deserialize(deserializer)?;
-    match &*s {
+    let s: &str = Deserialize::deserialize(deserializer)?;
+    match s {
         "0" => Ok(false),
         "1" => Ok(true),
         &_ => Err(serde::de::Error::custom(format!(

--- a/src/serde_helpers.rs
+++ b/src/serde_helpers.rs
@@ -111,7 +111,6 @@ where
     D: Deserializer<'de>,
 {
     String::deserialize(de).and_then(|s| {
-        let s = s.trim();
         if s.is_empty() {
             Ok(None)
         } else {
@@ -138,11 +137,10 @@ where
     D: Deserializer<'de>,
 {
     String::deserialize(de).and_then(|s| {
-        let s = s.trim();
         if s.is_empty() {
             Ok(None)
         } else {
-            parse_color(s).map(Some).map_err(de::Error::custom)
+            parse_color(&s).map(Some).map_err(de::Error::custom)
         }
     })
 }

--- a/src/serde_helpers.rs
+++ b/src/serde_helpers.rs
@@ -65,8 +65,8 @@ pub fn deserialize_time<'de, D>(deserializer: D) -> Result<u32, D::Error>
 where
     D: Deserializer<'de>,
 {
-    let s = String::deserialize(deserializer)?;
-    parse_time(&s).map_err(de::Error::custom)
+    let s: &str = Deserialize::deserialize(deserializer)?;
+    parse_time(s).map_err(de::Error::custom)
 }
 
 pub fn serialize_time<S>(time: &u32, serializer: S) -> Result<S::Ok, S::Error>
@@ -88,7 +88,7 @@ pub fn deserialize_optional_time<'de, D>(deserializer: D) -> Result<Option<u32>,
 where
     D: Deserializer<'de>,
 {
-    let s = Option::<String>::deserialize(deserializer)?;
+    let s: Option<&str> = Deserialize::deserialize(deserializer)?;
 
     match s {
         None => Ok(None),


### PR DESCRIPTION
This PR has a few small improvements, that combined yields in a reduction of about 40% in processing time.

Closes #111 

It has been benchmarked with data from https://transitfeeds.com/p/ov/814 https://transport.data.gouv.fr/resources/53943 and the dataset given in the original issue.

The performance was measured with:

```
hyperfine\
    --show-output\
    --export-markdown bench.md\
    --prepare 'cargo build --release --example reading'\
    'cargo run --release --example reading nl.zip'\
    'cargo run --release --example reading idfm.gtfs.zip'\
    'cargo run --release --example reading PID_GTFS.zip'
```

## Original

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `cargo run --release --example reading nl.zip` | 31.992 ± 0.050 | 31.907 | 32.062 | 318.33 ± 10.29 |
| `cargo run --release --example reading idfm.gtfs.zip` | 15.077 ± 0.025 | 15.044 | 15.132 | 1.00 |
| `cargo run --release --example reading PID_GTFS.zip` | 4.895 ± 0.013 | 4.878 | 4.912 | 48.70 ± 1.58 |

## Not using intermediate vec for parsing time
| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `cargo run --release --example reading nl.zip` | 29.480 ± 0.324 | 29.236 | 29.997 | 6.32 ± 0.08 |
| `cargo run --release --example reading idfm.gtfs.zip` | 13.536 ± 0.028 | 13.483 | 13.572 | 2.90 ± 0.02 |
| `cargo run --release --example reading PID_GTFS.zip` | 4.667 ± 0.032 | 4.628 | 4.739 | 1.00 |

## Deserializing time into &str, not String
| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `cargo run --release --example reading nl.zip` | 28.326 ± 0.054 | 28.247 | 28.419 | 6.28 ± 0.02 |
| `cargo run --release --example reading idfm.gtfs.zip` | 12.721 ± 0.051 | 12.661 | 12.805 | 2.82 ± 0.01 |
| `cargo run --release --example reading PID_GTFS.zip` | 4.511 ± 0.011 | 4.498 | 4.528 | 1.00 |

## More deserialize into &str, not String
| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `cargo run --release --example reading nl.zip` | 28.147 ± 0.048 | 28.044 | 28.206 | 6.26 ± 0.02 |
| `cargo run --release --example reading idfm.gtfs.zip` | 12.584 ± 0.040 | 12.521 | 12.673 | 2.80 ± 0.01 |
| `cargo run --release --example reading PID_GTFS.zip` | 4.495 ± 0.015 | 4.468 | 4.519 | 1.00 |

## No realloctaion of StringRecord
| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `cargo run --release --example reading nl.zip` | 26.998 ± 0.071 | 26.912 | 27.120 | 6.33 ± 0.03 |
| `cargo run --release --example reading idfm.gtfs.zip` | 12.138 ± 0.053 | 12.086 | 12.273 | 2.85 ± 0.02 |
| `cargo run --release --example reading PID_GTFS.zip` | 4.265 ± 0.016 | 4.246 | 4.293 | 1.00 |

## Without trimming
| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `cargo run --release --example reading nl.zip` | 18.204 ± 0.062 | 18.122 | 18.322 | 6.97 ± 0.05 |
| `cargo run --release --example reading idfm.gtfs.zip` | 7.322 ± 0.031 | 7.284 | 7.387 | 2.80 ± 0.02 |
| `cargo run --release --example reading PID_GTFS.zip` | 2.613 ± 0.017 | 2.596 | 2.650 | 1.00 |
