### PR TITLE
Implement `Clone` for `Trip`

### DIFF
--- a/src/objects.rs
+++ b/src/objects.rs
@@ -255,7 +255,7 @@ pub struct RawStopTime {
 }
 
 /// The moment where a vehicle, running on [Trip] stops at a [Stop]. See <https://gtfs.org/reference/static/#stopstxt>
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct StopTime {
     /// Arrival time of the stop time.
     /// It's an option since the intermediate stops can have have no arrival
@@ -424,7 +424,7 @@ impl fmt::Display for RawTrip {
 }
 
 /// A Trip is a vehicle that follows a sequence of [StopTime] on certain days. See <https://gtfs.org/reference/static/#tripstxt>
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct Trip {
     /// Unique technical identifier (not for the traveller) for the Trip
     pub id: String,
@@ -613,7 +613,7 @@ pub struct RawFrequency {
 }
 
 /// Timetables can be defined by the frequency of their vehicles. See <<https://gtfs.org/reference/static/#frequenciestxt>>
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct Frequency {
     /// Time at which the first vehicle departs from the first stop of the trip
     pub start_time: u32,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -199,6 +199,12 @@ fn trip_days() {
 }
 
 #[test]
+fn trip_clone() {
+    let gtfs = Gtfs::from_path("fixtures/basic/").unwrap();
+    let _: Trip = gtfs.trips.get("trip1").unwrap().clone();
+}
+
+#[test]
 fn read_from_gtfs() {
     let gtfs = Gtfs::from_path("fixtures/zips/gtfs.zip").unwrap();
     assert_eq!(1, gtfs.calendar.len());


### PR DESCRIPTION
This implements the `Clone` trait for the `Trip` struct (and thus for `Frequency` and `StopTime` too).

I am working on a project where I need to have an owned trip from the database, but since it was not clone-able I could only get a reference.

example code:

```rs
let trip: Trip = gtfs.trips.get("TRIP_ID").unwrap().clone();
```

before: `error: expected Trip, found &Trip`

after: **compiles**

Added a basic regression test.