### PR TITLE
BREAKING: add default value for route_color and route_text_color

### DIFF
--- a/src/objects.rs
+++ b/src/objects.rs
@@ -331,18 +331,18 @@ pub struct Route {
     pub route_order: Option<u32>,
     /// Route color designation that matches public facing material
     #[serde(
-        deserialize_with = "de_with_optional_color",
-        serialize_with = "serialize_optional_color",
-        default
+        deserialize_with = "deserialize_color",
+        serialize_with = "serialize_color",
+        default = "default_route_color"
     )]
-    pub route_color: Option<RGB8>,
+    pub route_color: RGB8,
     /// Legible color to use for text drawn against a background of [Route::route_color]
     #[serde(
-        deserialize_with = "de_with_optional_color",
-        serialize_with = "serialize_optional_color",
+        deserialize_with = "deserialize_color",
+        serialize_with = "serialize_color",
         default
     )]
-    pub route_text_color: Option<RGB8>,
+    pub route_text_color: RGB8,
     /// Indicates whether a rider can board the transit vehicle anywhere along the vehicle’s travel path
     #[serde(default)]
     pub continuous_pickup: ContinuousPickupDropOff,

--- a/src/serde_helpers.rs
+++ b/src/serde_helpers.rs
@@ -132,29 +132,22 @@ pub fn parse_color(s: &str) -> Result<RGB8, crate::Error> {
     Ok(RGB8::new(r, g, b))
 }
 
-pub fn de_with_optional_color<'de, D>(de: D) -> Result<Option<RGB8>, D::Error>
+pub fn deserialize_color<'de, D>(de: D) -> Result<RGB8, D::Error>
 where
     D: Deserializer<'de>,
 {
-    String::deserialize(de).and_then(|s| {
-        if s.is_empty() {
-            Ok(None)
-        } else {
-            parse_color(&s).map(Some).map_err(de::Error::custom)
-        }
-    })
+    String::deserialize(de).and_then(|s| parse_color(&s).map_err(de::Error::custom))
 }
 
-pub fn serialize_optional_color<S>(color: &Option<RGB8>, serializer: S) -> Result<S::Ok, S::Error>
+pub fn serialize_color<S>(color: &RGB8, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: Serializer,
 {
-    match color {
-        None => serializer.serialize_none(),
-        Some(RGB8 { r, g, b }) => {
-            serializer.serialize_str(format!("{:02X}{:02X}{:02X}", r, g, b).as_str())
-        }
-    }
+    serializer.serialize_str(format!("{:02X}{:02X}{:02X}", color.r, color.g, color.b).as_str())
+}
+
+pub fn default_route_color() -> RGB8 {
+    RGB8::new(255, 255, 255)
 }
 
 pub fn de_with_empty_default<'de, T: Default, D>(de: D) -> Result<T, D::Error>

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -56,12 +56,9 @@ fn read_routes() {
     let gtfs = Gtfs::from_path("fixtures/basic").expect("impossible to read gtfs");
     assert_eq!(2, gtfs.routes.len());
     assert_eq!(RouteType::Bus, gtfs.get_route("1").unwrap().route_type);
+    assert_eq!(RGB8::new(0, 0, 0), gtfs.get_route("1").unwrap().route_color);
     assert_eq!(
-        Some(RGB8::new(0, 0, 0)),
-        gtfs.get_route("1").unwrap().route_color
-    );
-    assert_eq!(
-        Some(RGB8::new(255, 255, 255)),
+        RGB8::new(255, 255, 255),
         gtfs.get_route("1").unwrap().route_text_color
     );
     assert_eq!(
@@ -341,8 +338,8 @@ fn read_only_required_fields() {
     let fare_attribute = gtfs.fare_attributes.get("50").unwrap();
     let feed = &gtfs.feed_info[0];
     let shape = &gtfs.shapes.get("A_shp").unwrap()[0];
-    assert_eq!(route.route_color, None);
-    assert_eq!(route.route_text_color, None);
+    assert_eq!(route.route_color, RGB8::new(255, 255, 255));
+    assert_eq!(route.route_text_color, RGB8::new(0, 0, 0));
     assert_eq!(fare_attribute.transfer_duration, None);
     assert_eq!(feed.start_date, None);
     assert_eq!(feed.end_date, None);


### PR DESCRIPTION
This implements the default values for `route_color` (white) and `route_text_color` (black) [per spec](https://developers.google.com/transit/gtfs/reference?authuser=3&hl=fi#routestxt).

As indicated in the issue too, this is a breaking change.

closes #93