### PR TITLE
BREAKING: follow naming conventions in Route struct

### DIFF
--- a/fixtures/basic/routes.txt
+++ b/fixtures/basic/routes.txt
@@ -1,3 +1,3 @@
-route_id,agency_id,route_short_name,route_long_name,route_desc,route_type,route_url,route_color,route_text_color
-1,848,"100","100","",3,,000000,FFFFFF
-invalid_type,848,"100","100","",42,,000000,FFFFFF
+route_id,agency_id,route_short_name,route_long_name,route_desc,route_type,route_url,route_color,route_text_color,route_sort_order
+1,848,"100","100","",3,,000000,FFFFFF,1
+invalid_type,848,"100","100","",42,,000000,FFFFFF,

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -326,9 +326,9 @@ pub struct Route {
     pub url: Option<String>,
     /// Agency for the specified route
     pub agency_id: Option<String>,
-    #[serde(rename = "route_sort_order")]
     /// Orders the routes in a way which is ideal for presentation to customers. Routes with smaller route_sort_order values should be displayed first.
-    pub route_order: Option<u32>,
+    #[serde(rename = "route_sort_order")]
+    pub order: Option<u32>,
     /// Route color designation that matches public facing material
     #[serde(
         deserialize_with = "deserialize_color",

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -333,16 +333,18 @@ pub struct Route {
     #[serde(
         deserialize_with = "deserialize_color",
         serialize_with = "serialize_color",
+        rename = "route_color",
         default = "default_route_color"
     )]
-    pub route_color: RGB8,
+    pub color: RGB8,
     /// Legible color to use for text drawn against a background of [Route::route_color]
     #[serde(
         deserialize_with = "deserialize_color",
         serialize_with = "serialize_color",
+        rename = "route_text_color",
         default
     )]
-    pub route_text_color: RGB8,
+    pub text_color: RGB8,
     /// Indicates whether a rider can board the transit vehicle anywhere along the vehicle’s travel path
     #[serde(default)]
     pub continuous_pickup: ContinuousPickupDropOff,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -61,6 +61,7 @@ fn read_routes() {
         RGB8::new(255, 255, 255),
         gtfs.get_route("1").unwrap().text_color
     );
+    assert_eq!(Some(1), gtfs.get_route("1").unwrap().order);
     assert_eq!(
         RouteType::Other(42),
         gtfs.get_route("invalid_type").unwrap().route_type

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -56,10 +56,10 @@ fn read_routes() {
     let gtfs = Gtfs::from_path("fixtures/basic").expect("impossible to read gtfs");
     assert_eq!(2, gtfs.routes.len());
     assert_eq!(RouteType::Bus, gtfs.get_route("1").unwrap().route_type);
-    assert_eq!(RGB8::new(0, 0, 0), gtfs.get_route("1").unwrap().route_color);
+    assert_eq!(RGB8::new(0, 0, 0), gtfs.get_route("1").unwrap().color);
     assert_eq!(
         RGB8::new(255, 255, 255),
-        gtfs.get_route("1").unwrap().route_text_color
+        gtfs.get_route("1").unwrap().text_color
     );
     assert_eq!(
         RouteType::Other(42),
@@ -344,8 +344,8 @@ fn read_only_required_fields() {
     let fare_attribute = gtfs.fare_attributes.get("50").unwrap();
     let feed = &gtfs.feed_info[0];
     let shape = &gtfs.shapes.get("A_shp").unwrap()[0];
-    assert_eq!(route.route_color, RGB8::new(255, 255, 255));
-    assert_eq!(route.route_text_color, RGB8::new(0, 0, 0));
+    assert_eq!(route.color, RGB8::new(255, 255, 255));
+    assert_eq!(route.text_color, RGB8::new(0, 0, 0));
     assert_eq!(fare_attribute.transfer_duration, None);
     assert_eq!(feed.start_date, None);
     assert_eq!(feed.end_date, None);


### PR DESCRIPTION
This renames `route_text_color` to `text_color`, `route_color` to `color` and `route_order` to `order` to follow naming conventions.

closes #94