### PR TITLE
Version 0.32.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Read GTFS (public transit timetables) files"
 name = "gtfs-structures"
-version = "0.31.0"
+version = "0.32.0"
 authors = ["Tristram Gräbener <tristramg@gmail.com>", "Antoine Desbordes <antoine.desbordes@gmail.com>"]
 repository = "https://github.com/rust-transit/gtfs-structure"
 license = "MIT"


### PR DESCRIPTION
Publish version 0.32.0 with a bunch of changes

## Breaking changes:
* https://github.com/rust-transit/gtfs-structure/pull/119
* https://github.com/rust-transit/gtfs-structure/pull/121

## Other changes:
* :walking_woman: :walking_man: https://github.com/rust-transit/gtfs-structure/pull/120
* https://github.com/rust-transit/gtfs-structure/pull/118