### PR TITLE
Fix empty route colors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Read GTFS (public transit timetables) files"
 name = "gtfs-structures"
-version = "0.32.0"
+version = "0.32.1"
 authors = ["Tristram Gräbener <tristramg@gmail.com>", "Antoine Desbordes <antoine.desbordes@gmail.com>"]
 repository = "https://github.com/rust-transit/gtfs-structure"
 license = "MIT"

--- a/fixtures/basic/routes.txt
+++ b/fixtures/basic/routes.txt
@@ -1,3 +1,4 @@
 route_id,agency_id,route_short_name,route_long_name,route_desc,route_type,route_url,route_color,route_text_color,route_sort_order
 1,848,"100","100","",3,,000000,FFFFFF,1
 invalid_type,848,"100","100","",42,,000000,FFFFFF,
+default_colors,848,"default_colors","route with default colors","",3,,,,1

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -334,7 +334,7 @@ pub struct Route {
     pub order: Option<u32>,
     /// Route color designation that matches public facing material
     #[serde(
-        deserialize_with = "deserialize_color",
+        deserialize_with = "deserialize_route_color",
         serialize_with = "serialize_color",
         rename = "route_color",
         default = "default_route_color"
@@ -342,7 +342,7 @@ pub struct Route {
     pub color: RGB8,
     /// Legible color to use for text drawn against a background of [Route::route_color]
     #[serde(
-        deserialize_with = "deserialize_color",
+        deserialize_with = "deserialize_route_text_color",
         serialize_with = "serialize_color",
         rename = "route_text_color",
         default

--- a/src/serde_helpers.rs
+++ b/src/serde_helpers.rs
@@ -119,7 +119,13 @@ where
     })
 }
 
-pub fn parse_color(s: &str) -> Result<RGB8, crate::Error> {
+pub fn parse_color(
+    s: &str,
+    default: impl std::ops::FnOnce() -> RGB8,
+) -> Result<RGB8, crate::Error> {
+    if s.is_empty() {
+        return Ok(default());
+    }
     if s.len() != 6 {
         return Err(crate::Error::InvalidColor(s.to_owned()));
     }
@@ -132,11 +138,19 @@ pub fn parse_color(s: &str) -> Result<RGB8, crate::Error> {
     Ok(RGB8::new(r, g, b))
 }
 
-pub fn deserialize_color<'de, D>(de: D) -> Result<RGB8, D::Error>
+pub fn deserialize_route_color<'de, D>(de: D) -> Result<RGB8, D::Error>
 where
     D: Deserializer<'de>,
 {
-    String::deserialize(de).and_then(|s| parse_color(&s).map_err(de::Error::custom))
+    String::deserialize(de)
+        .and_then(|s| parse_color(&s, default_route_color).map_err(de::Error::custom))
+}
+
+pub fn deserialize_route_text_color<'de, D>(de: D) -> Result<RGB8, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    String::deserialize(de).and_then(|s| parse_color(&s, RGB8::default).map_err(de::Error::custom))
 }
 
 pub fn serialize_color<S>(color: &RGB8, serializer: S) -> Result<S::Ok, S::Error>

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -54,12 +54,21 @@ fn read_stop() {
 #[test]
 fn read_routes() {
     let gtfs = Gtfs::from_path("fixtures/basic").expect("impossible to read gtfs");
-    assert_eq!(2, gtfs.routes.len());
+    assert_eq!(3, gtfs.routes.len());
     assert_eq!(RouteType::Bus, gtfs.get_route("1").unwrap().route_type);
     assert_eq!(RGB8::new(0, 0, 0), gtfs.get_route("1").unwrap().color);
     assert_eq!(
         RGB8::new(255, 255, 255),
         gtfs.get_route("1").unwrap().text_color
+    );
+    assert_eq!(RGB8::new(0, 0, 0), gtfs.get_route("1").unwrap().color);
+    assert_eq!(
+        RGB8::new(0, 0, 0),
+        gtfs.get_route("default_colors").unwrap().text_color
+    );
+    assert_eq!(
+        RGB8::new(255, 255, 255),
+        gtfs.get_route("default_colors").unwrap().color
     );
     assert_eq!(Some(1), gtfs.get_route("1").unwrap().order);
     assert_eq!(


### PR DESCRIPTION
The GTFS spec is a bit lenient toward default values. The route_color/route_text_color spec says "Defaults to <a value> when omitted or left empty".

We handled the omitted case, but not the empty one that we need to specifically handle