### PR TITLE
Correction mode => pathway_mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Read GTFS (public transit timetables) files"
 name = "gtfs-structures"
-version = "0.32.1"
+version = "0.32.2"
 authors = ["Tristram Gräbener <tristramg@gmail.com>", "Antoine Desbordes <antoine.desbordes@gmail.com>"]
 repository = "https://github.com/rust-transit/gtfs-structure"
 license = "MIT"

--- a/fixtures/basic/pathways.txt
+++ b/fixtures/basic/pathways.txt
@@ -1,2 +1,2 @@
-pathway_id,from_stop_id,to_stop_id,mode,is_bidirectional,length,traversal_time,stair_count,max_slope,min_width,signposted_as,reversed_signposted_as
+pathway_id,from_stop_id,to_stop_id,pathway_mode,is_bidirectional,length,traversal_time,stair_count,max_slope,min_width,signposted_as,reversed_signposted_as
 pathway1,stop1,stop3,1,0,,,,,,,

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -735,7 +735,7 @@ pub struct RawPathway {
     /// Location at which the pathway ends
     pub to_stop_id: String,
     /// Type of pathway between the specified (from_stop_id, to_stop_id) pair
-    pub mode: PathwayMode,
+    pub pathway_mode: PathwayMode,
     /// Indicates in which direction the pathway can be used
     pub is_bidirectional: PathwayDirectionType,
     /// Horizontal length in meters of the pathway from the origin location to the destination location
@@ -762,7 +762,7 @@ pub struct Pathway {
     /// Location at which the pathway ends
     pub to_stop_id: String,
     /// Type of pathway between the specified (from_stop_id, to_stop_id) pair
-    pub mode: PathwayMode,
+    pub pathway_mode: PathwayMode,
     /// Indicates in which direction the pathway can be used
     pub is_bidirectional: PathwayDirectionType,
     /// Horizontal length in meters of the pathway from the origin location to the destination location
@@ -793,7 +793,7 @@ impl From<RawPathway> for Pathway {
         Self {
             id: raw.id,
             to_stop_id: raw.to_stop_id,
-            mode: raw.mode,
+            pathway_mode: raw.pathway_mode,
             is_bidirectional: raw.is_bidirectional,
             length: raw.length,
             max_slope: raw.max_slope,

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -735,7 +735,8 @@ pub struct RawPathway {
     /// Location at which the pathway ends
     pub to_stop_id: String,
     /// Type of pathway between the specified (from_stop_id, to_stop_id) pair
-    pub pathway_mode: PathwayMode,
+   #[serde(rename = "pathway_mode")]
+    pub mode: PathwayMode,
     /// Indicates in which direction the pathway can be used
     pub is_bidirectional: PathwayDirectionType,
     /// Horizontal length in meters of the pathway from the origin location to the destination location

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -735,7 +735,7 @@ pub struct RawPathway {
     /// Location at which the pathway ends
     pub to_stop_id: String,
     /// Type of pathway between the specified (from_stop_id, to_stop_id) pair
-   #[serde(rename = "pathway_mode")]
+    #[serde(rename = "pathway_mode")]
     pub mode: PathwayMode,
     /// Indicates in which direction the pathway can be used
     pub is_bidirectional: PathwayDirectionType,
@@ -763,7 +763,7 @@ pub struct Pathway {
     /// Location at which the pathway ends
     pub to_stop_id: String,
     /// Type of pathway between the specified (from_stop_id, to_stop_id) pair
-    pub pathway_mode: PathwayMode,
+    pub mode: PathwayMode,
     /// Indicates in which direction the pathway can be used
     pub is_bidirectional: PathwayDirectionType,
     /// Horizontal length in meters of the pathway from the origin location to the destination location
@@ -794,7 +794,7 @@ impl From<RawPathway> for Pathway {
         Self {
             id: raw.id,
             to_stop_id: raw.to_stop_id,
-            pathway_mode: raw.pathway_mode,
+            mode: raw.mode,
             is_bidirectional: raw.is_bidirectional,
             length: raw.length,
             max_slope: raw.max_slope,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -190,7 +190,7 @@ fn read_pathways() {
 
     assert_eq!(1, pathways.len());
     assert_eq!("stop3", pathways[0].to_stop_id);
-    assert_eq!(PathwayMode::Walkway, pathways[0].mode);
+    assert_eq!(PathwayMode::Walkway, pathways[0].pathway_mode);
     assert_eq!(
         PathwayDirectionType::Unidirectional,
         pathways[0].is_bidirectional

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -190,7 +190,7 @@ fn read_pathways() {
 
     assert_eq!(1, pathways.len());
     assert_eq!("stop3", pathways[0].to_stop_id);
-    assert_eq!(PathwayMode::Walkway, pathways[0].pathway_mode);
+    assert_eq!(PathwayMode::Walkway, pathways[0].mode);
     assert_eq!(
         PathwayDirectionType::Unidirectional,
         pathways[0].is_bidirectional


### PR DESCRIPTION
It looks like the correct field name in pathways.txt is `pathway_mode`, not `mode`.

See https://developers.google.com/transit/gtfs/reference#pathwaystxt