### PR TITLE
Fix serialization errors with Serde and add a serialization/deserialization test

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,6 @@ rgb = "0.8"
 
 futures = { version = "0.3", optional = true }
 reqwest = { version = "0.11", optional = true, features = ["blocking"]}
+
+[dev-dependencies]
+serde_json = "1.0"

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -39,6 +39,9 @@ pub enum LocationType {
     Unknown(i32),
 }
 
+fn serialize_i32_as_str<S: Serializer>(s: S, value: i32) -> Result<S::Ok, S::Error> {
+    s.serialize_str(&value.to_string())
+}
 impl<'de> Deserialize<'de> for LocationType {
     fn deserialize<D>(deserializer: D) -> Result<LocationType, D::Error>
     where
@@ -67,14 +70,17 @@ impl Serialize for LocationType {
         S: Serializer,
     {
         // Note: for extended route type, we might loose the initial precise route type
-        serializer.serialize_i32(match self {
-            LocationType::StopPoint => 0,
-            LocationType::StopArea => 1,
-            LocationType::StationEntrance => 2,
-            LocationType::GenericNode => 3,
-            LocationType::BoardingArea => 4,
-            LocationType::Unknown(i) => *i,
-        })
+        serialize_i32_as_str(
+            serializer,
+            match self {
+                LocationType::StopPoint => 0,
+                LocationType::StopArea => 1,
+                LocationType::StationEntrance => 2,
+                LocationType::GenericNode => 3,
+                LocationType::BoardingArea => 4,
+                LocationType::Unknown(i) => *i,
+            },
+        )
     }
 }
 
@@ -203,13 +209,16 @@ impl Serialize for PickupDropOffType {
         S: Serializer,
     {
         // Note: for extended route type, we might loose the initial precise route type
-        serializer.serialize_i32(match self {
-            PickupDropOffType::Regular => 0,
-            PickupDropOffType::NotAvailable => 1,
-            PickupDropOffType::ArrangeByPhone => 2,
-            PickupDropOffType::CoordinateWithDriver => 3,
-            PickupDropOffType::Unknown(i) => *i,
-        })
+        serialize_i32_as_str(
+            serializer,
+            match self {
+                PickupDropOffType::Regular => 0,
+                PickupDropOffType::NotAvailable => 1,
+                PickupDropOffType::ArrangeByPhone => 2,
+                PickupDropOffType::CoordinateWithDriver => 3,
+                PickupDropOffType::Unknown(i) => *i,
+            },
+        )
     }
 }
 
@@ -238,13 +247,16 @@ impl Serialize for ContinuousPickupDropOff {
         S: Serializer,
     {
         // Note: for extended route type, we might loose the initial precise route type
-        serializer.serialize_i32(match self {
-            ContinuousPickupDropOff::Continuous => 0,
-            ContinuousPickupDropOff::NotAvailable => 1,
-            ContinuousPickupDropOff::ArrangeByPhone => 2,
-            ContinuousPickupDropOff::CoordinateWithDriver => 3,
-            ContinuousPickupDropOff::Unknown(i) => *i,
-        })
+        serialize_i32_as_str(
+            serializer,
+            match self {
+                ContinuousPickupDropOff::Continuous => 0,
+                ContinuousPickupDropOff::NotAvailable => 1,
+                ContinuousPickupDropOff::ArrangeByPhone => 2,
+                ContinuousPickupDropOff::CoordinateWithDriver => 3,
+                ContinuousPickupDropOff::Unknown(i) => *i,
+            },
+        )
     }
 }
 
@@ -274,9 +286,11 @@ impl<'de> Deserialize<'de> for ContinuousPickupDropOff {
 #[derivative(Default)]
 pub enum TimepointType {
     /// Times are considered approximate
+    #[serde(rename = "0")]
     Approximate = 0,
     /// Times are considered exact
     #[derivative(Default)]
+    #[serde(rename = "1")]
     Exact = 1,
 }
 
@@ -338,12 +352,15 @@ impl Serialize for Availability {
         S: Serializer,
     {
         // Note: for extended route type, we might loose the initial precise route type
-        serializer.serialize_i32(match self {
-            Availability::InformationNotAvailable => 0,
-            Availability::Available => 1,
-            Availability::NotAvailable => 2,
-            Availability::Unknown(i) => *i,
-        })
+        serialize_i32_as_str(
+            serializer,
+            match self {
+                Availability::InformationNotAvailable => 0,
+                Availability::Available => 1,
+                Availability::NotAvailable => 2,
+                Availability::Unknown(i) => *i,
+            },
+        )
     }
 }
 
@@ -410,12 +427,15 @@ impl Serialize for BikesAllowedType {
         S: Serializer,
     {
         // Note: for extended route type, we might loose the initial precise route type
-        serializer.serialize_i32(match self {
-            BikesAllowedType::NoBikeInfo => 0,
-            BikesAllowedType::AtLeastOneBike => 1,
-            BikesAllowedType::NoBikesAllowed => 2,
-            BikesAllowedType::Unknown(i) => *i,
-        })
+        serialize_i32_as_str(
+            serializer,
+            match self {
+                BikesAllowedType::NoBikeInfo => 0,
+                BikesAllowedType::AtLeastOneBike => 1,
+                BikesAllowedType::NoBikesAllowed => 2,
+                BikesAllowedType::Unknown(i) => *i,
+            },
+        )
     }
 }
 
@@ -497,10 +517,10 @@ impl Serialize for Transfers {
         S: Serializer,
     {
         match self {
-            Transfers::NoTransfer => serializer.serialize_i32(0),
-            Transfers::UniqueTransfer => serializer.serialize_i32(1),
-            Transfers::TwoTransfers => serializer.serialize_i32(2),
-            Transfers::Other(a) => serializer.serialize_i32(*a),
+            Transfers::NoTransfer => serialize_i32_as_str(serializer, 0),
+            Transfers::UniqueTransfer => serialize_i32_as_str(serializer, 1),
+            Transfers::TwoTransfers => serialize_i32_as_str(serializer, 2),
+            Transfers::Other(a) => serialize_i32_as_str(serializer, *a),
             Transfers::Unlimited => serializer.serialize_none(),
         }
     }

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -169,10 +169,12 @@ pub struct Stop {
     pub url: Option<String>,
     /// Longitude of the stop
     #[serde(deserialize_with = "de_with_optional_float")]
+    #[serde(serialize_with = "serialize_float_as_str")]
     #[serde(rename = "stop_lon", default)]
     pub longitude: Option<f64>,
     /// Latitude of the stop
     #[serde(deserialize_with = "de_with_optional_float")]
+    #[serde(serialize_with = "serialize_float_as_str")]
     #[serde(rename = "stop_lat", default)]
     pub latitude: Option<f64>,
     /// Timezone of the location

--- a/src/serde_helpers.rs
+++ b/src/serde_helpers.rs
@@ -119,6 +119,16 @@ where
     })
 }
 
+pub fn serialize_float_as_str<S>(float: &Option<f64>, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    match float {
+        None => serializer.serialize_str(""),
+        Some(f) => serializer.serialize_str(&f.to_string()),
+    }
+}
+
 pub fn parse_color(
     s: &str,
     default: impl std::ops::FnOnce() -> RGB8,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -5,6 +5,32 @@ use chrono::NaiveDate;
 use rgb::RGB8;
 
 #[test]
+fn serialization_deserialization() {
+    // route, trip, stop, stop_times
+    let gtfs = RawGtfs::from_path("fixtures/basic").expect("impossible to read gtfs");
+
+    let string = serde_json::to_string(&gtfs.routes.unwrap()).unwrap();
+    let _parsed: Vec<Route> = serde_json::from_str(&string).unwrap();
+
+    let string = serde_json::to_string(&gtfs.trips.unwrap()).unwrap();
+    let _parsed: Vec<RawTrip> = serde_json::from_str(&string).unwrap();
+
+    let string = serde_json::to_string(&gtfs.stops.unwrap()).unwrap();
+    let _parsed: Vec<Stop> = serde_json::from_str(&string).unwrap();
+
+    let string = serde_json::to_string(&gtfs.stop_times.unwrap()).unwrap();
+    let _parsed: Vec<RawStopTime> = serde_json::from_str(&string).unwrap();
+
+    let string = serde_json::to_string(&gtfs.frequencies.unwrap().unwrap()).unwrap();
+    let _parsed: Vec<RawFrequency> = serde_json::from_str(&string).unwrap();
+
+    let string = serde_json::to_string(&gtfs.pathways.unwrap().unwrap()).unwrap();
+    let _parsed: Vec<RawPathway> = serde_json::from_str(&string).unwrap();
+
+    let string = serde_json::to_string(&gtfs.transfers.unwrap().unwrap()).unwrap();
+    let _parsed: Vec<RawTransfer> = serde_json::from_str(&string).unwrap();
+}
+#[test]
 fn read_calendar() {
     let gtfs = Gtfs::from_path("fixtures/basic").expect("impossible to read gtfs");
     assert_eq!(1, gtfs.calendar.len());


### PR DESCRIPTION
Right now, serializing items with Serde errors out because the types are wrong. For example, wheelchair boarding `Availability` serializes as `i32` but deserializes as `str`. This leads to an error when we test round-trip serialization (serialize then deserialize).

I fixed and added one test for this issue.