### PR TITLE
Better error message for wrong stop_id in transfers.txt

### DIFF
--- a/examples/reading.rs
+++ b/examples/reading.rs
@@ -13,6 +13,6 @@ fn main() {
         Ok(g) => {
             g.print_stats();
         }
-        Err(e) => eprintln!("error: {:?}", e),
+        Err(e) => eprintln!("error: {e:?}"),
     }
 }

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -56,8 +56,7 @@ impl<'de> Deserialize<'de> for LocationType {
             "4" => LocationType::BoardingArea,
             s => LocationType::Unknown(s.parse().map_err(|_| {
                 serde::de::Error::custom(format!(
-                    "invalid value for LocationType, must be an integer: {}",
-                    s
+                    "invalid value for LocationType, must be an integer: {s}"
                 ))
             })?),
         })
@@ -195,8 +194,7 @@ impl<'de> Deserialize<'de> for PickupDropOffType {
             "3" => PickupDropOffType::CoordinateWithDriver,
             s => PickupDropOffType::Unknown(s.parse().map_err(|_| {
                 serde::de::Error::custom(format!(
-                    "invalid value for PickupDropOffType, must be an integer: {}",
-                    s
+                    "invalid value for PickupDropOffType, must be an integer: {s}"
                 ))
             })?),
         })
@@ -273,8 +271,7 @@ impl<'de> Deserialize<'de> for ContinuousPickupDropOff {
             "3" => ContinuousPickupDropOff::CoordinateWithDriver,
             s => ContinuousPickupDropOff::Unknown(s.parse().map_err(|_| {
                 serde::de::Error::custom(format!(
-                    "invalid value for ContinuousPickupDropOff, must be an integer: {}",
-                    s
+                    "invalid value for ContinuousPickupDropOff, must be an integer: {s}"
                 ))
             })?),
         })
@@ -304,8 +301,7 @@ impl<'de> Deserialize<'de> for TimepointType {
             "" | "1" => Ok(Self::Exact),
             "0" => Ok(Self::Approximate),
             v => Err(serde::de::Error::custom(format!(
-                "invalid value for timepoint: {}",
-                v
+                "invalid value for timepoint: {v}"
             ))),
         }
     }
@@ -338,8 +334,7 @@ impl<'de> Deserialize<'de> for Availability {
             "2" => Availability::NotAvailable,
             s => Availability::Unknown(s.parse().map_err(|_| {
                 serde::de::Error::custom(format!(
-                    "invalid value for Availability, must be an integer: {}",
-                    s
+                    "invalid value for Availability, must be an integer: {s}"
                 ))
             })?),
         })
@@ -413,8 +408,7 @@ impl<'de> Deserialize<'de> for BikesAllowedType {
             "2" => BikesAllowedType::NoBikesAllowed,
             s => BikesAllowedType::Unknown(s.parse().map_err(|_| {
                 serde::de::Error::custom(format!(
-                    "invalid value for BikeAllowedType, must be an integer: {}",
-                    s
+                    "invalid value for BikeAllowedType, must be an integer: {s}"
                 ))
             })?),
         })
@@ -470,8 +464,7 @@ impl<'de> Deserialize<'de> for ExactTimes {
             "1" => ExactTimes::ScheduleBased,
             &_ => {
                 return Err(serde::de::Error::custom(format!(
-                    "Invalid value `{}`, expected 0 or 1",
-                    s
+                    "Invalid value `{s}`, expected 0 or 1"
                 )))
             }
         })

--- a/src/gtfs.rs
+++ b/src/gtfs.rs
@@ -241,18 +241,18 @@ fn to_stop_map(
         stops.into_iter().map(|s| (s.id.clone(), s)).collect();
 
     for transfer in raw_transfers {
-        stop_map
-            .get(&transfer.to_stop_id)
-            .ok_or_else(|| Error::ReferenceError(format!("'{}' in transfers.txt", transfer.to_stop_id)))?;
+        stop_map.get(&transfer.to_stop_id).ok_or_else(|| {
+            Error::ReferenceError(format!("'{}' in transfers.txt", transfer.to_stop_id))
+        })?;
         stop_map
             .entry(transfer.from_stop_id.clone())
             .and_modify(|stop| stop.transfers.push(StopTransfer::from(transfer)));
     }
 
     for pathway in raw_pathways {
-        stop_map
-            .get(&pathway.to_stop_id)
-            .ok_or_else(|| Error::ReferenceError(format!("'{}' in pathways.txt", pathway.to_stop_id)))?;
+        stop_map.get(&pathway.to_stop_id).ok_or_else(|| {
+            Error::ReferenceError(format!("'{}' in pathways.txt", pathway.to_stop_id))
+        })?;
         stop_map
             .entry(pathway.from_stop_id.clone())
             .and_modify(|stop| stop.pathways.push(Pathway::from(pathway)));

--- a/src/gtfs.rs
+++ b/src/gtfs.rs
@@ -243,7 +243,7 @@ fn to_stop_map(
     for transfer in raw_transfers {
         stop_map
             .get(&transfer.to_stop_id)
-            .ok_or_else(|| Error::ReferenceError(transfer.to_stop_id.to_string()))?;
+            .ok_or_else(|| Error::ReferenceError(format!("'{}' in transfers.txt", transfer.to_stop_id)))?;
         stop_map
             .entry(transfer.from_stop_id.clone())
             .and_modify(|stop| stop.transfers.push(StopTransfer::from(transfer)));
@@ -252,7 +252,7 @@ fn to_stop_map(
     for pathway in raw_pathways {
         stop_map
             .get(&pathway.to_stop_id)
-            .ok_or_else(|| Error::ReferenceError(pathway.to_stop_id.to_string()))?;
+            .ok_or_else(|| Error::ReferenceError(format!("'{}' in pathways.txt", pathway.to_stop_id)))?;
         stop_map
             .entry(pathway.from_stop_id.clone())
             .and_modify(|stop| stop.pathways.push(Pathway::from(pathway)));

--- a/src/gtfs.rs
+++ b/src/gtfs.rs
@@ -242,7 +242,8 @@ fn to_stop_map(
 
     for transfer in raw_transfers {
         stop_map.get(&transfer.to_stop_id).ok_or_else(|| {
-            Error::ReferenceError(format!("'{}' in transfers.txt", transfer.to_stop_id))
+            let stop_id = &transfer.to_stop_id;
+            Error::ReferenceError(format!("'{stop_id}' in transfers.txt"))
         })?;
         stop_map
             .entry(transfer.from_stop_id.clone())
@@ -251,7 +252,8 @@ fn to_stop_map(
 
     for pathway in raw_pathways {
         stop_map.get(&pathway.to_stop_id).ok_or_else(|| {
-            Error::ReferenceError(format!("'{}' in pathways.txt", pathway.to_stop_id))
+            let stop_id = &pathway.to_stop_id;
+            Error::ReferenceError(format!("'{stop_id}' in pathways.txt"))
         })?;
         stop_map
             .entry(pathway.from_stop_id.clone())

--- a/src/gtfs_reader.rs
+++ b/src/gtfs_reader.rs
@@ -285,7 +285,7 @@ impl RawGtfsReader {
             shapes: self.read_optional_file(&file_mapping, &mut archive, "shapes.txt"),
             read_duration: Utc::now().signed_duration_since(now).num_milliseconds(),
             files,
-            sha256: Some(format!("{:x}", hash)),
+            sha256: Some(format!("{hash:x}")),
         };
 
         if self.reader.unkown_enum_as_default {

--- a/src/raw_gtfs.rs
+++ b/src/raw_gtfs.rs
@@ -146,7 +146,7 @@ impl RawGtfs {
 fn mandatory_file_summary<T>(objs: &Result<Vec<T>, Error>) -> String {
     match objs {
         Ok(vec) => format!("{} objects", vec.len()),
-        Err(e) => format!("Could not read {}", e),
+        Err(e) => format!("Could not read {e}"),
     }
 }
 

--- a/src/serde_helpers.rs
+++ b/src/serde_helpers.rs
@@ -191,8 +191,7 @@ where
         "0" => Ok(false),
         "1" => Ok(true),
         &_ => Err(serde::de::Error::custom(format!(
-            "Invalid value `{}`, expected 0 or 1",
-            s
+            "Invalid value `{s}`, expected 0 or 1"
         ))),
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -232,18 +232,18 @@ fn read_feed_info() {
     assert_eq!("SNCF", feed[0].name);
     assert_eq!("http://www.sncf.com", feed[0].url);
     assert_eq!("fr", feed[0].lang);
-    assert_eq!(Some(NaiveDate::from_ymd(2018, 07, 09)), feed[0].start_date);
-    assert_eq!(Some(NaiveDate::from_ymd(2018, 09, 27)), feed[0].end_date);
+    assert_eq!(Some(NaiveDate::from_ymd(2018, 7, 9)), feed[0].start_date);
+    assert_eq!(Some(NaiveDate::from_ymd(2018, 9, 27)), feed[0].end_date);
     assert_eq!(Some("0.3".to_string()), feed[0].version);
 }
 
 #[test]
 fn trip_days() {
     let gtfs = Gtfs::from_path("fixtures/basic/").unwrap();
-    let days = gtfs.trip_days(&"service1".to_owned(), NaiveDate::from_ymd(2017, 1, 1));
+    let days = gtfs.trip_days("service1", NaiveDate::from_ymd(2017, 1, 1));
     assert_eq!(vec![6, 7, 13, 14], days);
 
-    let days2 = gtfs.trip_days(&"service2".to_owned(), NaiveDate::from_ymd(2017, 1, 1));
+    let days2 = gtfs.trip_days("service2", NaiveDate::from_ymd(2017, 1, 1));
     assert_eq!(vec![0], days2);
 }
 
@@ -414,7 +414,7 @@ fn sorted_shapes() {
     let shape = &gtfs.shapes.get("Unordered_shp").unwrap();
 
     let points = shape
-        .into_iter()
+        .iter()
         .map(|s| (s.sequence, s.latitude, s.longitude))
         .collect::<Vec<_>>();
 


### PR DESCRIPTION
...and pathways.txt

linked to https://github.com/etalab/transport-site/issues/2958

I was wondering if I was misusing the Error, just passing the filename with the stop_id like that?

But the error is used in other context, where the filename is not necessarily known, so maybe it is fine. Let me know :)

Thanks!