### PR TITLE
Add default values for route_short_name and route_long_name

### DIFF
--- a/src/objects.rs
+++ b/src/objects.rs
@@ -316,10 +316,10 @@ pub struct Route {
     #[serde(rename = "route_id")]
     pub id: String,
     /// Short name of a route. This will often be a short, abstract identifier like "32", "100X", or "Green" that riders use to identify a route, but which doesn't give any indication of what places the route serves
-    #[serde(rename = "route_short_name")]
+    #[serde(rename = "route_short_name", default)]
     pub short_name: String,
     /// Full name of a route. This name is generally more descriptive than the [Route::short_name]] and often includes the route's destination or stop
-    #[serde(rename = "route_long_name")]
+    #[serde(rename = "route_long_name", default)]
     pub long_name: String,
     /// Description of a route that provides useful, quality information
     #[serde(rename = "route_desc")]


### PR DESCRIPTION
They are only ['conditionally required'](https://gtfs.org/schedule/reference/#routestxt).

Determining the 'requiredness' seems more a validation question and cannot be determined during deserialization.

Alternatively, they could be `Option<String>`s which is a more correct representation when the column is missing, but makes user code more complicated.