### PR TITLE
Update TransferType Enum

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Read GTFS (public transit timetables) files"
 name = "gtfs-structures"
-version = "0.33.1"
+version = "0.33.2"
 authors = ["Tristram Gräbener <tristramg@gmail.com>", "Antoine Desbordes <antoine.desbordes@gmail.com>"]
 repository = "https://github.com/rust-transit/gtfs-structure"
 license = "MIT"

--- a/fixtures/basic/transfers.txt
+++ b/fixtures/basic/transfers.txt
@@ -1,3 +1,6 @@
 from_stop_id,to_stop_id,transfer_type,min_transfer_time
 stop3,stop5,0,60
 stop1,stop2,3,
+stop2,stop3,,
+stop5,stop2,4,
+stop5,stop3,5,

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -549,19 +549,17 @@ impl<'de> Deserialize<'de> for TransferType {
     where
         D: Deserializer<'de>,
     {
-        let i = Option::<i32>::deserialize(deserializer)?;
-        Ok(match i {
-            Some(0) => TransferType::Recommended,
-            Some(1) => TransferType::Timed,
-            Some(2) => TransferType::MinTime,
-            Some(3) => TransferType::Impossible,
-            Some(4) => TransferType::StayOnBoard,
-            Some(5) => TransferType::MustAlight,
-            None => TransferType::default(),
-            _ => {
+        let s: String = String::deserialize(deserializer)?;
+        Ok(match s.as_str() {
+            "" | "0" => TransferType::Recommended,
+            "1" => TransferType::Timed,
+            "2" => TransferType::MinTime,
+            "3" => TransferType::Impossible,
+            "4" => TransferType::StayOnBoard,
+            "5" => TransferType::MustAlight,
+            s => {
                 return Err(serde::de::Error::custom(format!(
-                    "Invalid value `{:?}`, expected 0, 1, 2, 3, 4, 5",
-                    i
+                    "Invalid value `{s}`, expected 0, 1, 2, 3, 4, 5"
                 )))
             }
         })

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -519,7 +519,7 @@ impl Serialize for Transfers {
     }
 }
 /// Defines the type of a [StopTransfer]
-#[derive(Debug, Serialize, Deserialize, Derivative, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Serialize, Derivative, Copy, Clone, PartialEq, Eq)]
 #[derivative(Default)]
 pub enum TransferType {
     /// Recommended transfer point between routes
@@ -535,6 +535,37 @@ pub enum TransferType {
     /// Transfer is not possible at this location
     #[serde(rename = "3")]
     Impossible,
+    /// Passengers can stay onboard the same vehicle to transfer from one trip to another
+    #[serde(rename = "4")]
+    StayOnBoard,
+    /// In-seat transfers aren't allowed between sequential trips.
+    /// The passenger must alight from the vehicle and re-board.
+    #[serde(rename = "5")]
+    MustAlight,
+}
+
+impl<'de> Deserialize<'de> for TransferType {
+    fn deserialize<D>(deserializer: D) -> Result<TransferType, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let i = Option::<i32>::deserialize(deserializer)?;
+        Ok(match i {
+            Some(0) => TransferType::Recommended,
+            Some(1) => TransferType::Timed,
+            Some(2) => TransferType::MinTime,
+            Some(3) => TransferType::Impossible,
+            Some(4) => TransferType::StayOnBoard,
+            Some(5) => TransferType::MustAlight,
+            None => TransferType::default(),
+            _ => {
+                return Err(serde::de::Error::custom(format!(
+                    "Invalid value `{:?}`, expected 0, 1, 2, 3, 4, 5",
+                    i
+                )))
+            }
+        })
+    }
 }
 
 /// Type of pathway between [from_stop] and [to_stop]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -206,6 +206,18 @@ fn read_transfers() {
         None,
         gtfs.get_stop("stop1").unwrap().transfers[0].min_transfer_time
     );
+    assert_eq!(
+        TransferType::Recommended,
+        gtfs.get_stop("stop2").unwrap().transfers[0].transfer_type
+    );
+    assert_eq!(
+        TransferType::StayOnBoard,
+        gtfs.get_stop("stop5").unwrap().transfers[0].transfer_type
+    );
+    assert_eq!(
+        TransferType::MustAlight,
+        gtfs.get_stop("stop5").unwrap().transfers[1].transfer_type
+    );
 }
 
 #[test]


### PR DESCRIPTION
According to the GTFS documentation, an empty value for a transfer_type is equivalent to `0`.

Also, values `4` and `5` were not implemented.

I think only a custom deserialization is needed for this Enum, and a Serialization is not necessary, am I right?