### PR TITLE
Update zips dependency

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,4 @@
-on: [push]
+on: [push, pull_request]
 
 name: Tests and linting
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ serde_derive = "1.0"
 chrono = "0.4"
 itertools = "0.10"
 sha2 = "0.10"
-zip = "0.5"
+zip = "0.6"
 thiserror = "1"
 rgb = "0.8"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Read GTFS (public transit timetables) files"
 name = "gtfs-structures"
-version = "0.33.2"
+version = "0.34.0"
 authors = ["Tristram Gräbener <tristramg@gmail.com>", "Antoine Desbordes <antoine.desbordes@gmail.com>"]
 repository = "https://github.com/rust-transit/gtfs-structure"
 license = "MIT"


### PR DESCRIPTION
```
❯ cargo outdated
All dependencies are up to date, yay!
```
🎉

And bump version to 0.34.0 to do a release