### PR TITLE
Release RawStopTime earlier

### DIFF
--- a/src/gtfs.rs
+++ b/src/gtfs.rs
@@ -292,7 +292,7 @@ fn to_calendar_dates(cd: Vec<CalendarDate>) -> HashMap<String, Vec<CalendarDate>
 
 fn create_trips(
     raw_trips: Vec<RawTrip>,
-    raw_stop_times: Vec<RawStopTime>,
+    mut raw_stop_times: Vec<RawStopTime>,
     raw_frequencies: Vec<RawFrequency>,
     stops: &HashMap<String, Arc<Stop>>,
 ) -> Result<HashMap<String, Trip>, Error> {
@@ -310,7 +310,8 @@ fn create_trips(
         bikes_allowed: rt.bikes_allowed,
         frequencies: vec![],
     }));
-    for s in raw_stop_times {
+
+    while let Some(s) = raw_stop_times.pop() {
         let trip = &mut trips
             .get_mut(&s.trip_id)
             .ok_or_else(|| Error::ReferenceError(s.trip_id.to_string()))?;
@@ -318,6 +319,7 @@ fn create_trips(
             .get(&s.stop_id)
             .ok_or_else(|| Error::ReferenceError(s.stop_id.to_string()))?;
         trip.stop_times.push(StopTime::from(&s, Arc::clone(stop)));
+        raw_stop_times.shrink_to_fit();
     }
 
     for trip in &mut trips.values_mut() {


### PR DESCRIPTION
linked to https://github.com/etalab/transport-validator/issues/172

Memory consumption is too great because we do the parsing in 2 phases, first into a `RawGtfs` then into a `Gtfs` and during the conversion we have both structures in memory, resulting in doubling the peak memory needed. In the [FR IDF](https://eu.ftp.opendatasoft.com/stif/GTFS/IDFM-gtfs.zip) dataset (~13 000 000 stop times), the RawGTFS takes 2.3 G or memory and the GTFs 2.1G, and the peak memory needed is ~3.9.

This PR add a reverse loop on the stop times and schrink to fit the vector (reverse iterating so not to allocate a new vector). Even if it's a naive implementation (we shouldn't have to schrink_to_fit it at every element), it seems the performance impact is negligible and on the IDF dataset `/usr/bin/time` measure goes from 3.9G to 3.4G