### PR TITLE
`Pathway::stair_count` can be negative

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Read GTFS (public transit timetables) files"
 name = "gtfs-structures"
-version = "0.35.0"
+version = "0.36.0"
 authors = ["Tristram Gräbener <tristramg@gmail.com>", "Antoine Desbordes <antoine.desbordes@gmail.com>"]
 repository = "https://github.com/rust-transit/gtfs-structure"
 license = "MIT"

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -746,7 +746,7 @@ pub struct RawPathway {
     /// Average time in seconds needed to walk through the pathway from the origin location to the destination location
     pub traversal_time: Option<u32>,
     /// Number of stairs of the pathway
-    pub stair_count: Option<u32>,
+    pub stair_count: Option<i32>,
     /// Maximum slope ratio of the pathway
     pub max_slope: Option<f32>,
     /// Minimum width of the pathway in meters
@@ -773,7 +773,7 @@ pub struct Pathway {
     /// Average time in seconds needed to walk through the pathway from the origin location to the destination location
     pub traversal_time: Option<u32>,
     /// Number of stairs of the pathway
-    pub stair_count: Option<u32>,
+    pub stair_count: Option<i32>,
     /// Maximum slope ratio of the pathway
     pub max_slope: Option<f32>,
     /// Minimum width of the pathway in meters


### PR DESCRIPTION
> A positive `stair_count` implies that the rider walk up from `from_stop_id`
> to `to_stop_id`. And a negative `stair_count` implies that the rider walk
> down from `from_stop_id` to `to_stop_id`.
(https://gtfs.org/schedule/reference/#pathwaystxt)