### PR TITLE
Limit the number of shrink to fit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Read GTFS (public transit timetables) files"
 name = "gtfs-structures"
-version = "0.36.0"
+version = "0.36.1"
 authors = ["Tristram Gräbener <tristramg@gmail.com>", "Antoine Desbordes <antoine.desbordes@gmail.com>"]
 repository = "https://github.com/rust-transit/gtfs-structure"
 license = "MIT"


### PR DESCRIPTION
This is not very important, but it seems a waste to do it for each stop time. This reduce a bit the loading time, but not in a really important way (tested on the Ile de france mobilité dataset).