### PR TITLE
Add a new `RawGTFS::SourceFormat` field and strip file paths.

### DIFF
--- a/src/objects.rs
+++ b/src/objects.rs
@@ -808,3 +808,12 @@ impl From<RawPathway> for Pathway {
         }
     }
 }
+
+/// Format of the data
+#[derive(Debug, Serialize, PartialEq)]
+pub enum SourceFormat {
+    /// `Directory` means the data comes from a directory
+    Directory,
+    /// `Zip` means the data were read from a zip
+    Zip,
+}

--- a/src/raw_gtfs.rs
+++ b/src/raw_gtfs.rs
@@ -39,6 +39,8 @@ pub struct RawGtfs {
     pub stop_times: Result<Vec<RawStopTime>, Error>,
     /// All files that are present in the feed
     pub files: Vec<String>,
+    /// Format of the data read
+    pub source_format: SourceFormat,
     /// sha256 sum of the feed
     pub sha256: Option<String>,
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -341,12 +341,15 @@ fn display() {
 fn path_files() {
     let gtfs = RawGtfs::from_path("fixtures/basic").expect("impossible to read gtfs");
     assert_eq!(gtfs.files.len(), 13);
+    assert_eq!(gtfs.source_format, SourceFormat::Directory);
+    assert!(gtfs.files.contains(&"agency.txt".to_owned()));
 }
 
 #[test]
 fn zip_files() {
     let gtfs = RawGtfs::from_path("fixtures/zips/gtfs.zip").expect("impossible to read gtfs");
     assert_eq!(gtfs.files.len(), 10);
+    assert_eq!(gtfs.source_format, SourceFormat::Zip);
     assert!(gtfs.files.contains(&"agency.txt".to_owned()));
 }
 
@@ -355,6 +358,7 @@ fn zip_subdirectory_files() {
     let gtfs =
         RawGtfs::from_path("fixtures/zips/subdirectory.zip").expect("impossible to read gtfs");
     assert_eq!(gtfs.files.len(), 11);
+    assert_eq!(gtfs.source_format, SourceFormat::Zip);
     assert!(gtfs.files.contains(&"subdirectory/agency.txt".to_owned()));
 }
 


### PR DESCRIPTION
The new SourceFormat store the fact that the GTFS has been read from a directory or a zip.

Also strip the base path in the `files` field of the `RawGTFS`. This way, if the data were were from a directory with:
`RawGTFS::new("some/path/to/read")`, the `files` will contains `stops.txt` and not `some/path/to/read/stops.txt`. It's more consistent to the way it will be if the data is read from a zip (and makes it possible to know if the data were in a subfolder).