### PR TITLE
allow for train voyages longer than 4.1 days

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Read GTFS (public transit timetables) files"
 name = "gtfs-structures"
-version = "0.37.0"
+version = "0.37.1"
 authors = ["Tristram Gräbener <tristramg@gmail.com>", "Antoine Desbordes <antoine.desbordes@gmail.com>"]
 repository = "https://github.com/rust-transit/gtfs-structure"
 license = "MIT"


### PR DESCRIPTION
I recently encountered this error in my ingestion feed:
```
f-u4-ruter~flybussen~stfoldkollektivtrafikk~hedmarktrafikk~oppla is not a valid gtfs feed
CSVError { file_name: "stop_times.txt", source: Error(Deserialize { pos: Some(Position { byte: 99651536, line: 1007487, record: 1007487 }), err: DeserializeError { field: None, kind: Message("'100:35:00' is not a valid time; HH:MM:SS format is expected.") } }), line_in_error: Some(LineError { headers: ["trip_id", "stop_id", "arrival_time", "departure_time", "stop_sequence", "stop_headsign", "pickup_type", "drop_off_type", "shape_dist_traveled"], values: ["HAV:ServiceJourney:2023-09-03", "NSR:Quay:99528", "100:35:00", "100:50:00", "21", "", "", "", ""] }) }
```

It appears this train in Norway takes more than 4 days to complete it's voyage and is legitimate. I've rewritten the rest of the time parser to still conform to HH:MM:SS.