### PR TITLE
Add ability to skip shapes reading

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Read GTFS (public transit timetables) files"
 name = "gtfs-structures"
-version = "0.38.0"
+version = "0.39.0"
 authors = ["Tristram Gräbener <tristramg@gmail.com>", "Antoine Desbordes <antoine.desbordes@gmail.com>"]
 repository = "https://github.com/rust-transit/gtfs-structure"
 license = "MIT"

--- a/src/gtfs.rs
+++ b/src/gtfs.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 ///
 /// This structure is easier to use than the [RawGtfs] structure as some relationships are parsed to be easier to use.
 ///
-/// If you want to configure the behaviour (e.g. skipping : [StopTime]), see [crate::GtfsReader] for more personalisation
+/// If you want to configure the behaviour (e.g. skipping : [StopTime] or [Shape]), see [crate::GtfsReader] for more personalisation
 ///
 /// This is probably the entry point you want to use:
 /// ```

--- a/src/gtfs_reader.rs
+++ b/src/gtfs_reader.rs
@@ -40,12 +40,12 @@ pub struct GtfsReader {
     /// [crate::objects::Shape] are very large and not always needed. This allows to skip reading them
     #[derivative(Default(value = "true"))]
     pub read_shapes: bool,
-    /// If a an enumeration has un unknown value, should we use the default value
+    /// If a an enumeration has an unknown value, should we use the default value
     #[derivative(Default(value = "false"))]
     pub unkown_enum_as_default: bool,
     /// Avoid trimming the fields
     ///
-    /// It is quite time consumming
+    /// It is quite time consuming
     /// If performance is an issue, and if your data is high quality, you can switch it off
     #[derivative(Default(value = "true"))]
     pub trim_fields: bool,


### PR DESCRIPTION
Some of the shape files are enormous and not always required for every task. 