### PR TITLE
Remove Nonstatic Zip & Reqwest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ thiserror = "1"
 rgb = "0.8"
 
 futures = { version = "0.3", optional = true }
-reqwest = { version = "0.11", optional = true, features = ["blocking"]}
+reqwest = { version = "0.11", optional = true, default-features = false, features = ["blocking", "rustls-tls"]}
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ serde_derive = "1.0"
 chrono = "0.4"
 itertools = "0.12"
 sha2 = "0.10"
-zip = { version = "0.6.6", default-features = false }
+zip = { version = "0.6.6", default-features = false, features = ["deflate"] }
 thiserror = "1"
 rgb = "0.8"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ serde_derive = "1.0"
 chrono = "0.4"
 itertools = "0.12"
 sha2 = "0.10"
-zip = { version = "0.6.6", default-features = false, features = ["deflate"] }
+zip = { git = "https://github.com/lolpro11/zip" }
 thiserror = "1"
 rgb = "0.8"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,9 @@ derivative = "2.1"
 serde = {version = "1.0", features = ["rc"]}
 serde_derive = "1.0"
 chrono = "0.4"
-itertools = "0.11"
+itertools = "0.12"
 sha2 = "0.10"
-zip = "0.6"
+zip = { version = "0.6.6", default-features = false }
 thiserror = "1"
 rgb = "0.8"
 


### PR DESCRIPTION
This does not affect the functionality of the crate, as this does not use zstd. Same thing with using rust-tls. We are just switching tls libraries.
These changes will allow a static compile of this library.  