### PR TITLE
Add TTS Stop Time and make route / stop names optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Read GTFS (public transit timetables) files"
 name = "gtfs-structures"
-version = "0.40.0"
+version = "0.41.0"
 authors = ["Tristram Gräbener <tristramg@gmail.com>", "Antoine Desbordes <antoine.desbordes@gmail.com>"]
 repository = "https://github.com/rust-transit/gtfs-structure"
 license = "MIT"

--- a/examples/gtfs_raw_reader.rs
+++ b/examples/gtfs_raw_reader.rs
@@ -11,5 +11,5 @@ fn main() {
 
     let routes = gtfs.routes.expect("impossible to read routes");
     let route_1 = routes.first().expect("no route");
-    println!("{}: {:?}", route_1.short_name, route_1);
+    println!("{}: {:?}", route_1.short_name.as_ref().unwrap(), route_1);
 }

--- a/examples/gtfs_reader.rs
+++ b/examples/gtfs_reader.rs
@@ -11,5 +11,5 @@ fn main() {
     println!("there are {} stops in the gtfs", gtfs.stops.len());
 
     let route_1 = gtfs.routes.get("1").expect("no route 1");
-    println!("{}: {:?}", route_1.short_name, route_1);
+    println!("{}: {:?}", route_1.short_name.as_ref().unwrap(), route_1);
 }

--- a/examples/gtfs_reading.rs
+++ b/examples/gtfs_reading.rs
@@ -11,5 +11,5 @@ fn main() {
     println!("there are {} stops in the gtfs", gtfs.stops.len());
 
     let route_1 = gtfs.routes.get("1").expect("no route 1");
-    println!("{}: {:?}", route_1.short_name, route_1);
+    println!("{}: {:?}", route_1.short_name.as_ref().unwrap(), route_1);
 }

--- a/examples/raw_gtfs_reading.rs
+++ b/examples/raw_gtfs_reading.rs
@@ -9,6 +9,6 @@ fn main() {
     raw_gtfs.print_stats();
 
     for stop in raw_gtfs.stops.expect("impossible to read stops.txt") {
-        println!("stop: {}", stop.name);
+        println!("stop: {}", stop.name.unwrap_or(String::from("")));
     }
 }

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -153,10 +153,10 @@ pub struct Stop {
     pub code: Option<String>,
     ///Name of the location. Use a name that people will understand in the local and tourist vernacular
     #[serde(rename = "stop_name")]
-    pub name: String,
+    pub name: Option<String>,
     /// Description of the location that provides useful, quality information
     #[serde(default, rename = "stop_desc")]
-    pub description: String,
+    pub description: Option<String>,
     /// Type of the location
     #[serde(default)]
     pub location_type: LocationType,
@@ -212,7 +212,7 @@ impl Id for Stop {
 
 impl fmt::Display for Stop {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.name)
+        write!(f, "{}", self.name.clone().unwrap_or(String::from("")))
     }
 }
 

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -193,6 +193,9 @@ pub struct Stop {
     /// Pathways from this stop
     #[serde(skip)]
     pub pathways: Vec<Pathway>,
+    /// Text to speech readable version of the stop_name
+    #[serde(rename = "tts_stop_name")]
+    pub tts_name: Option<String>
 }
 
 impl Type for Stop {
@@ -317,10 +320,10 @@ pub struct Route {
     pub id: String,
     /// Short name of a route. This will often be a short, abstract identifier like "32", "100X", or "Green" that riders use to identify a route, but which doesn't give any indication of what places the route serves
     #[serde(rename = "route_short_name", default)]
-    pub short_name: String,
+    pub short_name: Option<String>,
     /// Full name of a route. This name is generally more descriptive than the [Route::short_name]] and often includes the route's destination or stop
     #[serde(rename = "route_long_name", default)]
-    pub long_name: String,
+    pub long_name: Option<String>,
     /// Description of a route that provides useful, quality information
     #[serde(rename = "route_desc")]
     pub desc: Option<String>,
@@ -372,10 +375,12 @@ impl Id for Route {
 
 impl fmt::Display for Route {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        if !self.long_name.is_empty() {
-            write!(f, "{}", self.long_name)
+        if self.long_name.is_some() {
+            write!(f, "{}", self.long_name.as_ref().unwrap())
+        } else if self.short_name.is_some() {
+            write!(f, "{}", self.short_name.as_ref().unwrap())
         } else {
-            write!(f, "{}", self.short_name)
+            write!(f, "{}", self.id)
         }
     }
 }

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -195,7 +195,7 @@ pub struct Stop {
     pub pathways: Vec<Pathway>,
     /// Text to speech readable version of the stop_name
     #[serde(rename = "tts_stop_name")]
-    pub tts_name: Option<String>
+    pub tts_name: Option<String>,
 }
 
 impl Type for Stop {

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -212,7 +212,7 @@ impl Id for Stop {
 
 impl fmt::Display for Stop {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.name.clone().unwrap_or(String::from("")))
+        write!(f, "{}", self.name.as_ref().unwrap_or(&String::from("")))
     }
 }
 
@@ -375,10 +375,10 @@ impl Id for Route {
 
 impl fmt::Display for Route {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        if self.long_name.is_some() {
-            write!(f, "{}", self.long_name.as_ref().unwrap())
-        } else if self.short_name.is_some() {
-            write!(f, "{}", self.short_name.as_ref().unwrap())
+        if let Some(long_name) = self.long_name.as_ref() {
+            write!(f, "{}", long_name)
+        } else if let Some(short_name) = self.short_name.as_ref() {
+            write!(f, "{}", short_name)
         } else {
             write!(f, "{}", self.id)
         }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -310,7 +310,7 @@ fn display() {
         format!(
             "{}",
             Stop {
-                name:Some("Sorano".to_owned()),
+                name: Some("Sorano".to_owned()),
                 ..Stop::default()
             }
         )

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -310,7 +310,7 @@ fn display() {
         format!(
             "{}",
             Stop {
-                name: "Sorano".to_owned(),
+                name:Some("Sorano".to_owned()),
                 ..Stop::default()
             }
         )
@@ -321,7 +321,8 @@ fn display() {
         format!(
             "{}",
             Route {
-                long_name: "Long route name".to_owned(),
+                long_name: Some("Long route name".to_owned()),
+                short_name: None,
                 ..Route::default()
             }
         )
@@ -332,7 +333,8 @@ fn display() {
         format!(
             "{}",
             Route {
-                short_name: "Short route name".to_owned(),
+                short_name: Some("Short route name".to_owned()),
+                long_name: None,
                 ..Route::default()
             }
         )
@@ -415,7 +417,7 @@ fn read_interpolated_stops() {
     // the second stop have no departure/arrival, it should not cause any problems
     assert_eq!(
         gtfs.trips["trip1"].stop_times[1].stop.name,
-        "Stop Point child of 1"
+        Some("Stop Point child of 1".to_owned())
     );
     assert!(gtfs.trips["trip1"].stop_times[1].arrival_time.is_none());
 }


### PR DESCRIPTION
To the Rust Transit maintainer team,

According to the GTFS specification, route_short_name and route_long_name are optional if the other one is empty. Should we throw an error if both are empty? 

Additionally, stops.txt defines `tts_stop_name` as a new optional field which is added for users who rely on screenreaders to navigate the world.  A stop_name is not required for generic / boarding nodes, and a stop_desc is never required. Thus, these have also been made optional.

This small change is ready for production. Thank you for reviewing and considering this pull request in advance.

Cordially, 
Kyler Chin