### PR TITLE
Make Gtfs::from_path to accept non-displayable path

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Read GTFS (public transit timetables) files"
 name = "gtfs-structures"
-version = "0.41.0"
+version = "0.41.1"
 authors = ["Tristram Gräbener <tristramg@gmail.com>", "Antoine Desbordes <antoine.desbordes@gmail.com>"]
 repository = "https://github.com/rust-transit/gtfs-structure"
 license = "MIT"

--- a/src/gtfs.rs
+++ b/src/gtfs.rs
@@ -107,7 +107,7 @@ impl Gtfs {
     /// Reads the GTFS from a local zip archive or local directory
     pub fn from_path<P>(path: P) -> Result<Gtfs, Error>
     where
-        P: AsRef<std::path::Path> + std::fmt::Display,
+        P: AsRef<std::path::Path>,
     {
         RawGtfs::from_path(path).and_then(Gtfs::try_from)
     }

--- a/src/gtfs_reader.rs
+++ b/src/gtfs_reader.rs
@@ -225,7 +225,7 @@ impl RawGtfsReader {
     /// Reads the raw GTFS from a local zip archive or local directory
     pub fn read_from_path<P>(&self, path: P) -> Result<RawGtfs, Error>
     where
-        P: AsRef<Path> + std::fmt::Display,
+        P: AsRef<Path>,
     {
         let p = path.as_ref();
         if p.is_file() {

--- a/src/raw_gtfs.rs
+++ b/src/raw_gtfs.rs
@@ -85,7 +85,7 @@ impl RawGtfs {
     /// Reads the raw GTFS from a local zip archive or local directory
     pub fn from_path<P>(path: P) -> Result<Self, Error>
     where
-        P: AsRef<Path> + std::fmt::Display,
+        P: AsRef<Path>,
     {
         GtfsReader::default().raw().read_from_path(path)
     }


### PR DESCRIPTION
`Gtfs::from_path` have where clause to force argument to implement `Display`.

But not called function are really want this.

It may be a relic to build a error string on `RawGtfsReader::read_from_path` but now it use `p.display()`