### PR TITLE
Add options to disable default features for `zip` and `reqwest` and enable rustls-tls for reqwest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,10 @@ license = "MIT"
 edition = "2018"
 
 [features]
-default = ["read-url", "zip-full"]
+default = ["read-url", "zip-full", "reqwest-full"]
 read-url = ["reqwest", "futures"]
 zip-full = ["zip/default"]
+reqwest-full = ["reqwest/default"]
 
 [dependencies]
 bytes = "1"
@@ -25,8 +26,8 @@ thiserror = "1"
 rgb = "0.8"
 
 futures = { version = "0.3", optional = true }
-reqwest = { version = "0.11", optional = true, features = ["blocking"]}
-zip = { version = "0.6", default-features = false, features = [ "deflate" ] }
+reqwest = { version = "0.11", optional = true, default-features = false, features = ["blocking", "rustls-tls"]}
+zip = { version = "0.6", default-features = false, features = ["deflate"] }
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,10 +8,11 @@ license = "MIT"
 edition = "2018"
 
 [features]
-default = ["read-url", "zip-full", "reqwest-full"]
+default = ["read-url", "zip-default", "reqwest-default"]
 read-url = ["reqwest", "futures"]
-zip-full = ["zip/default"]
-reqwest-full = ["reqwest/default"]
+zip-default = ["zip/default"]
+reqwest-default = ["reqwest/default"]
+reqwest-rustls-tls = ["reqwest/rustls-tls"]
 
 [dependencies]
 bytes = "1"
@@ -26,7 +27,7 @@ thiserror = "1"
 rgb = "0.8"
 
 futures = { version = "0.3", optional = true }
-reqwest = { version = "0.11", optional = true, default-features = false, features = ["blocking", "rustls-tls"]}
+reqwest = { version = "0.11", optional = true, default-features = false, features = ["blocking"]}
 zip = { version = "0.6", default-features = false, features = ["deflate"] }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,9 @@ license = "MIT"
 edition = "2018"
 
 [features]
-default = ["read-url"]
+default = ["read-url", "zip-full"]
 read-url = ["reqwest", "futures"]
+zip-full = ["zip/default"]
 
 [dependencies]
 bytes = "1"
@@ -20,12 +21,12 @@ serde_derive = "1.0"
 chrono = "0.4"
 itertools = "0.11"
 sha2 = "0.10"
-zip = "0.6"
 thiserror = "1"
 rgb = "0.8"
 
 futures = { version = "0.3", optional = true }
 reqwest = { version = "0.11", optional = true, features = ["blocking"]}
+zip = { version = "0.6", default-features = false, features = [ "deflate" ] }
 
 [dev-dependencies]
 serde_json = "1.0"


### PR DESCRIPTION
Alternative to #153. Shouldn't change anything by default, but will allow a Rust-only build by disabling some default features:

```
gtfs-structures = { version = "0.41.2", default-features=false, features=["read-url", "reqwest-rustls-tls" ] }
```