### PR TITLE
Implement hashing for many basic enums

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Read GTFS (public transit timetables) files"
 name = "gtfs-structures"
-version = "0.41.2"
+version = "0.41.3"
 authors = ["Tristram Gräbener <tristramg@gmail.com>", "Antoine Desbordes <antoine.desbordes@gmail.com>"]
 repository = "https://github.com/rust-transit/gtfs-structure"
 license = "MIT"

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -167,7 +167,7 @@ impl Serialize for RouteType {
 }
 
 /// Describes if and how a traveller can board or alight the vehicle. See <https://gtfs.org/reference/static/#stop_timestxt> `pickup_type` and `dropoff_type`
-#[derive(Debug, Derivative, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Derivative, Copy, Clone, PartialEq, Eq, Hash)]
 #[derivative(Default(bound = ""))]
 pub enum PickupDropOffType {
     /// Regularly scheduled pickup or drop off (default when empty).
@@ -225,7 +225,7 @@ impl Serialize for PickupDropOffType {
 /// Indicates whether a rider can board the transit vehicle anywhere along the vehicle’s travel path
 ///
 /// Those values are only defined on <https://developers.google.com/transit/gtfs/reference#routestxt,> not on <https://gtfs.org/reference/static/#routestxt>
-#[derive(Debug, Derivative, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Derivative, Copy, Clone, PartialEq, Eq, Hash)]
 #[derivative(Default(bound = ""))]
 pub enum ContinuousPickupDropOff {
     /// Continuous stopping pickup or drop off.
@@ -281,7 +281,7 @@ impl<'de> Deserialize<'de> for ContinuousPickupDropOff {
 }
 
 /// Describes if the stop time is exact or not. See <https://gtfs.org/reference/static/#stop_timestxt> `timepoint`
-#[derive(Debug, Derivative, Serialize, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Derivative, Serialize, Copy, Clone, PartialEq, Eq, Hash)]
 #[derivative(Default)]
 pub enum TimepointType {
     /// Times are considered approximate
@@ -373,7 +373,7 @@ pub enum Exception {
 }
 
 /// Defines the direction of a [Trip], only for display, not for routing. See <https://gtfs.org/reference/static/#tripstxt> `direction_id`
-#[derive(Debug, Deserialize, Serialize, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Deserialize, Serialize, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum DirectionType {
     /// Travel in one direction (e.g. outbound travel).
     #[serde(rename = "0")]
@@ -384,7 +384,7 @@ pub enum DirectionType {
 }
 
 /// Is the [Trip] accessible with a bike. See <https://gtfs.org/reference/static/#tripstxt> `bikes_allowed`
-#[derive(Debug, Derivative, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Derivative, Copy, Clone, PartialEq, Eq, Hash)]
 #[derivative(Default())]
 pub enum BikesAllowedType {
     /// No bike information for the trip
@@ -447,7 +447,7 @@ pub enum PaymentMethod {
 }
 
 /// Defines if the [Frequency] is exact (the vehicle runs exactly every n minutes) or not
-#[derive(Debug, Serialize, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Serialize, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum ExactTimes {
     /// Frequency-based trips
     FrequencyBased = 0,
@@ -474,7 +474,7 @@ impl<'de> Deserialize<'de> for ExactTimes {
 }
 
 /// Defines how many transfers can be done with on [FareAttribute]
-#[derive(Debug, Derivative, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Derivative, Copy, Clone, PartialEq, Eq, Hash)]
 #[derivative(Default(bound = ""))]
 pub enum Transfers {
     /// Unlimited transfers are permitted
@@ -521,7 +521,7 @@ impl Serialize for Transfers {
     }
 }
 /// Defines the type of a [StopTransfer]
-#[derive(Debug, Serialize, Derivative, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Serialize, Derivative, Copy, Clone, PartialEq, Eq, Hash)]
 #[derivative(Default)]
 pub enum TransferType {
     /// Recommended transfer point between routes
@@ -569,7 +569,7 @@ impl<'de> Deserialize<'de> for TransferType {
 }
 
 /// Type of pathway between [from_stop] and [to_stop]
-#[derive(Debug, Serialize, Deserialize, Derivative, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Serialize, Deserialize, Derivative, Copy, Clone, PartialEq, Eq, Hash)]
 #[derivative(Default)]
 pub enum PathwayMode {
     /// A walkway
@@ -599,7 +599,7 @@ pub enum PathwayMode {
 }
 
 /// Indicates in which direction the pathway can be used
-#[derive(Debug, Serialize, Deserialize, Derivative, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Serialize, Deserialize, Derivative, Copy, Clone, PartialEq, Eq, Hash)]
 #[derivative(Default)]
 pub enum PathwayDirectionType {
     /// Unidirectional pathway, it can only be used from [from_stop_id] to [to_stop_id].

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -3,6 +3,7 @@ use crate::serde_helpers::*;
 use chrono::{Datelike, NaiveDate, Weekday};
 use rgb::RGB8;
 
+use std::hash::{Hash, Hasher};
 use std::fmt;
 use std::sync::Arc;
 
@@ -33,7 +34,7 @@ impl<T: Type> Type for Arc<T> {
 }
 
 /// A calender describes on which days the vehicle runs. See <https://gtfs.org/reference/static/#calendartxt>
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize, Hash, PartialEq, Eq)]
 pub struct Calendar {
     /// Unique technical identifier (not for the traveller) of this calendar
     #[serde(rename = "service_id")]

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -4,7 +4,7 @@ use chrono::{Datelike, NaiveDate, Weekday};
 use rgb::RGB8;
 
 use std::fmt;
-use std::hash::{Hash, Hasher};
+use std::hash::Hash;
 use std::sync::Arc;
 
 /// Objects that have an identifier implement this trait

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -3,8 +3,8 @@ use crate::serde_helpers::*;
 use chrono::{Datelike, NaiveDate, Weekday};
 use rgb::RGB8;
 
-use std::hash::{Hash, Hasher};
 use std::fmt;
+use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
 /// Objects that have an identifier implement this trait


### PR DESCRIPTION
I don't have a use for implementing Hash for Trips or StopTimes yet, nor a good workaround for `Option<f32>` types.

 I'm working on compression of schedules and I think at least the enums should implement hashing to allow direct comparison of time intervals. Most implementions of schedule parsers, such as Google Maps, likely do not store the entire dataset. I attempted to do that and it wound up being over 200 GB for the entire world. Implementations typically store the difference between each stop as an itinerary, and then trips are referenced via an offset to the itinerary. I can copy over the pickup and dropoff fields, and timepoint into my own struct and compute a hash of it, which becomes the Itinerary, then use it to match trip ids with a previous itinerary, along with an offset.
 
 This paper describes it quite well: https://ad-publications.informatik.uni-freiburg.de/SIGSPATIAL_Frequency_based_Search_BBS_2014.pdf

Like my previous `Clone` pull request, this does increase compile time but is not a breaking change, nor does it worsen runtime.

Thank you so much once again,
Kyler Chin