### PR TITLE
Avoid temporary allocations during Deserialization

### DIFF
--- a/src/enums.rs
+++ b/src/enums.rs
@@ -49,8 +49,8 @@ impl<'de> Deserialize<'de> for LocationType {
     where
         D: Deserializer<'de>,
     {
-        let s: String = String::deserialize(deserializer)?;
-        Ok(match s.as_str() {
+        let s = <&str>::deserialize(deserializer)?;
+        Ok(match s {
             "" | "0" => LocationType::StopPoint,
             "1" => LocationType::StopArea,
             "2" => LocationType::StationEntrance,
@@ -188,8 +188,8 @@ impl<'de> Deserialize<'de> for PickupDropOffType {
     where
         D: Deserializer<'de>,
     {
-        let s: String = String::deserialize(deserializer)?;
-        Ok(match s.as_str() {
+        let s = <&str>::deserialize(deserializer)?;
+        Ok(match s {
             "" | "0" => PickupDropOffType::Regular,
             "1" => PickupDropOffType::NotAvailable,
             "2" => PickupDropOffType::ArrangeByPhone,
@@ -265,8 +265,8 @@ impl<'de> Deserialize<'de> for ContinuousPickupDropOff {
     where
         D: Deserializer<'de>,
     {
-        let s: String = String::deserialize(deserializer)?;
-        Ok(match s.as_str() {
+        let s = <&str>::deserialize(deserializer)?;
+        Ok(match s {
             "0" => ContinuousPickupDropOff::Continuous,
             "" | "1" => ContinuousPickupDropOff::NotAvailable,
             "2" => ContinuousPickupDropOff::ArrangeByPhone,
@@ -298,8 +298,8 @@ impl<'de> Deserialize<'de> for TimepointType {
     where
         D: Deserializer<'de>,
     {
-        let s: String = String::deserialize(deserializer)?;
-        match s.as_str() {
+        let s = <&str>::deserialize(deserializer)?;
+        match s {
             "" | "1" => Ok(Self::Exact),
             "0" => Ok(Self::Approximate),
             v => Err(serde::de::Error::custom(format!(
@@ -329,8 +329,8 @@ impl<'de> Deserialize<'de> for Availability {
     where
         D: Deserializer<'de>,
     {
-        let s: String = String::deserialize(deserializer)?;
-        Ok(match s.as_str() {
+        let s = <&str>::deserialize(deserializer)?;
+        Ok(match s {
             "" | "0" => Availability::InformationNotAvailable,
             "1" => Availability::Available,
             "2" => Availability::NotAvailable,
@@ -403,8 +403,8 @@ impl<'de> Deserialize<'de> for BikesAllowedType {
     where
         D: Deserializer<'de>,
     {
-        let s: String = String::deserialize(deserializer)?;
-        Ok(match s.as_str() {
+        let s = <&str>::deserialize(deserializer)?;
+        Ok(match s {
             "" | "0" => BikesAllowedType::NoBikeInfo,
             "1" => BikesAllowedType::AtLeastOneBike,
             "2" => BikesAllowedType::NoBikesAllowed,
@@ -460,8 +460,8 @@ impl<'de> Deserialize<'de> for ExactTimes {
     where
         D: Deserializer<'de>,
     {
-        let s: String = String::deserialize(deserializer)?;
-        Ok(match s.as_str() {
+        let s = <&str>::deserialize(deserializer)?;
+        Ok(match s {
             "" | "0" => ExactTimes::FrequencyBased,
             "1" => ExactTimes::ScheduleBased,
             &_ => {
@@ -551,8 +551,8 @@ impl<'de> Deserialize<'de> for TransferType {
     where
         D: Deserializer<'de>,
     {
-        let s: String = String::deserialize(deserializer)?;
-        Ok(match s.as_str() {
+        let s = <&str>::deserialize(deserializer)?;
+        Ok(match s {
             "" | "0" => TransferType::Recommended,
             "1" => TransferType::Timed,
             "2" => TransferType::MinTime,

--- a/src/serde_helpers.rs
+++ b/src/serde_helpers.rs
@@ -49,24 +49,25 @@ pub fn parse_time_impl(h: &str, m: &str, s: &str) -> Result<u32, std::num::Parse
 }
 
 pub fn parse_time(s: &str) -> Result<u32, crate::Error> {
+    let mk_err = || crate::Error::InvalidTime(s.to_owned());
+
     if s.len() < 7 {
-        Err(crate::Error::InvalidTime(s.to_owned()))
+        Err(mk_err())
     } else {
-        let parts: Vec<&str> = s.split(':').collect();
+        let mut parts = s.split(':');
 
-        if parts.len() != 3 {
-            return Err(crate::Error::InvalidTime(s.to_owned()));
+        let hour = parts.next().ok_or_else(mk_err)?;
+        let min = parts.next().ok_or_else(mk_err)?;
+        let sec = parts.next().ok_or_else(mk_err)?;
+        if parts.next().is_some() {
+            return Err(mk_err());
         }
-
-        let sec = parts[2];
-        let min = parts[1];
-        let hour = parts[0];
 
         if min.len() != 2 || sec.len() != 2 {
-            return Err(crate::Error::InvalidTime(s.to_owned()));
+            return Err(mk_err());
         }
 
-        parse_time_impl(hour, min, sec).map_err(|_| crate::Error::InvalidTime(s.to_owned()))
+        parse_time_impl(hour, min, sec).map_err(|_| mk_err())
     }
 }
 


### PR DESCRIPTION
These allocations represent in total ~6% of decoding CPU time.