### PR TITLE
Update Error Struct to be cloneable

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -11,7 +11,7 @@ pub struct LineError {
 }
 
 /// An error that can occur when processing GTFS data.
-#[derive(Error, Debug)]
+#[derive(Clone, Error, Debug)]
 pub enum Error {
     /// A mandatory file is not present in the archive
     #[error("Cound not find file {0}")]


### PR DESCRIPTION
This is so I can pass the error message out of a function