### PR TITLE
Remove an unused trait bound.

### DIFF
--- a/src/gtfs_reader.rs
+++ b/src/gtfs_reader.rs
@@ -99,7 +99,7 @@ impl GtfsReader {
     /// Reads the raw GTFS from a local zip archive or local directory
     pub fn read_from_path<P>(self, path: P) -> Result<Gtfs, Error>
     where
-        P: AsRef<Path> + std::fmt::Display,
+        P: AsRef<Path>,
     {
         self.raw().read_from_path(path).and_then(Gtfs::try_from)
     }


### PR DESCRIPTION
Nothing uses this Display bound, RawGtfsReader lacks a similar bound, and paths in general are not Display (because there is no well-defined way to interpret non-ASCII bytes in them).