### PR TITLE
Remove the “ms” prefix in `Gtfs.print_stats`

### DIFF
--- a/src/gtfs.rs
+++ b/src/gtfs.rs
@@ -88,7 +88,7 @@ impl Gtfs {
     /// Prints on stdout some basic statistics about the GTFS file (numbers of elements for each object). Mostly to be sure that everything was read
     pub fn print_stats(&self) {
         println!("GTFS data:");
-        println!("  Read in {:?} ms", self.read_duration);
+        println!("  Read in {:?}", self.read_duration);
         println!("  Stops: {}", self.stops.len());
         println!("  Routes: {}", self.routes.len());
         println!("  Trips: {}", self.trips.len());


### PR DESCRIPTION
The switch to a duration introduced in commit c0f170f makes the need to print an extra “ms” unnecessary, as it is already handled in the Rust standard library.

For reference,
- the `fmt` function: https://doc.rust-lang.org/src/core/time.rs.html#1241
- its automatic prefixing: https://doc.rust-lang.org/src/core/time.rs.html#1402