### PR TITLE
Make stop_sequence u32

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Read GTFS (public transit timetables) files"
 name = "gtfs-structures"
-version = "0.42.0"
+version = "0.43.0"
 authors = [
     "Tristram Gräbener <tristramg@gmail.com>",
     "Antoine Desbordes <antoine.desbordes@gmail.com>",

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -241,7 +241,7 @@ pub struct RawStopTime {
     /// Identifier of the [Stop] where the vehicle stops
     pub stop_id: String,
     /// Order of stops for a particular trip. The values must increase along the trip but do not need to be consecutive
-    pub stop_sequence: u16,
+    pub stop_sequence: u32,
     /// Text that appears on signage identifying the trip's destination to riders
     pub stop_headsign: Option<String>,
     /// Indicates pickup method
@@ -281,7 +281,7 @@ pub struct StopTime {
     /// Indicates drop off method
     pub drop_off_type: PickupDropOffType,
     /// Order of stops for a particular trip. The values must increase along the trip but do not need to be consecutive
-    pub stop_sequence: u16,
+    pub stop_sequence: u32,
     /// Text that appears on signage identifying the trip's destination to riders
     pub stop_headsign: Option<String>,
     /// Indicates whether a rider can board the transit vehicle anywhere along the vehicle’s travel path


### PR DESCRIPTION
Some rail companies (MAV-Start) decided to put ridiculous high numbers (99990) as stop sequence count for the last stop in a journey. I am not sure if this should actually be changed here. Is there any size limit set for this field by the "Standard"?