### PR TITLE
Make extended route types survive a parsing / serializing round trip

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Read GTFS (public transit timetables) files"
 name = "gtfs-structures"
-version = "0.48.2"
+version = "0.49.0"
 authors = [
     "Tristram Gräbener <tristramg@gmail.com>",
     "Antoine Desbordes <antoine.desbordes@gmail.com>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ web-time = "1.1.0"
 
 futures = { version = "0.3", optional = true }
 reqwest = { version = "0.13", optional = true, features = ["blocking"] }
+derive_more = { version = "2.1", features = ["try_from"] }
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -84,14 +84,194 @@ impl Serialize for LocationType {
     }
 }
 
+#[derive(Debug, Clone, derive_more::TryFrom, Copy, PartialEq, Eq, Hash)]
+#[repr(i16)]
+#[try_from(repr)]
+/// Google Transit extended route types [https://developers.google.com/transit/gtfs/reference/extended-route-types](https://developers.google.com/transit/gtfs/reference/extended-route-types)
+pub enum ExtendedRouteType {
+    /// Railway Service.
+    Railway = 100,
+    /// High Speed Rail Service. Examples: TGV (FR), ICE (DE), Eurostar (GB).
+    HighSpeedRail = 101,
+    /// Long Distance Trains. Examples: InterCity/EuroCity.
+    LongDistanceTrains = 102,
+    /// Inter Regional Rail Service. Examples: InterRegio (DE), Cross County Rail (GB).
+    InterRegionalRail = 103,
+    /// Car Transport Rail Service.
+    CarTransportRail = 104,
+    /// Sleeper Rail Service. Example: GNER Sleeper (GB).
+    SleeperRail = 105,
+    /// Regional Rail Service. Examples: TER (FR), Regionalzug (DE).
+    RegionalRail = 106,
+    /// Tourist Railway Service. Example: Romney, Hythe & Dymchurch (GB).
+    TouristRailway = 107,
+    /// Rail Shuttle (Within Complex). Examples: Gatwick Shuttle (GB), Sky Line (DE).
+    RailShuttleWithinComplex = 108,
+    /// Suburban Railway. Examples: S-Bahn (DE), RER (FR), S-tog (Kopenhagen).
+    SuburbanRailway = 109,
+    /// Replacement Rail Service.
+    ReplacementRail = 110,
+    /// Special Rail Service.
+    SpecialRail = 111,
+    /// Lorry Transport Rail Service.
+    LorryTransportRail = 112,
+    /// All Rail Services.
+    OtherRail = 113,
+    /// Cross-Country Rail Service.
+    CrossCountryRail = 114,
+    /// Vehicle Transport Rail Service.
+    VehicleTransportRail = 115,
+    /// Rack and Pinion Railway. Examples: Rochers de Naye (CH), Dolderbahn (CH).
+    RackAndPinionRailway = 116,
+    /// Additional Rail Service.
+    AdditionalRail = 117,
+
+    /// Coach Service.
+    Coach = 200,
+    /// International Coach Service. Examples: EuroLine, Touring.
+    InternationalCoach = 201,
+    /// National Coach Service. Example: National Express (GB).
+    NationalCoach = 202,
+    /// Shuttle Coach Service. Examples: Roissy Bus (FR), Reading-Heathrow (GB).
+    ShuttleCoach = 203,
+    /// Regional Coach Service.
+    RegionalCoach = 204,
+    /// Special Coach Service.
+    SpecialCoach = 205,
+    /// Sightseeing Coach Service.
+    SightseeingCoach = 206,
+    /// Tourist Coach Service.
+    TouristCoach = 207,
+    /// Commuter Coach Service.
+    CommuterCoach = 208,
+    /// All Coach Services.
+    OtherCoach = 209,
+
+    /// Urban Railway Service.
+    UrbanRailway = 400,
+    /// Metro Service. Example: Métro de Paris.
+    Metro = 401,
+    /// Underground Service. Examples: London Underground, U-Bahn.
+    Underground = 402,
+    /// Urban Railway Service.
+    UrbanRailwayServiceDetail = 403,
+    /// All Urban Railway Services.
+    OtherUrbanRailway = 404,
+    /// Monorail.
+    Monorail = 405,
+
+    /// Bus Service.
+    Bus = 700,
+    /// Regional Bus Service. Example: Eastbourne-Maidstone (GB).
+    RegionalBus = 701,
+    /// Express Bus Service. Example: X19 Wokingham-Heathrow (GB).
+    ExpressBus = 702,
+    /// Stopping Bus Service. Example: 38 London: Clapton Pond-Victoria (GB).
+    StoppingBus = 703,
+    /// Local Bus Service.
+    LocalBus = 704,
+    /// Night Bus Service. Example: N prefixed buses in London (GB).
+    NightBus = 705,
+    /// Post Bus Service. Example: Maidstone P4 (GB).
+    PostBus = 706,
+    /// Special Needs Bus.
+    SpecialNeedsBus = 707,
+    /// Mobility Bus Service.
+    MobilityBus = 708,
+    /// Mobility Bus for Registered Disabled.
+    MobilityBusForRegisteredDisabled = 709,
+    /// Sightseeing Bus.
+    SightseeingBus = 710,
+    /// Shuttle Bus. Example: 747 Heathrow-Gatwick Airport Service (GB).
+    ShuttleBus = 711,
+    /// School Bus.
+    SchoolBus = 712,
+    /// School and Public Service Bus.
+    SchoolAndPublicServiceBus = 713,
+    /// Rail Replacement Bus Service.
+    RailReplacementBus = 714,
+    /// Demand and Response Bus Service.
+    DemandAndResponseBus = 715,
+    /// All Bus Services.
+    OtherBus = 716,
+
+    /// Trolleybus Service.
+    Trolleybus = 800,
+
+    /// Tram Service.
+    Tram = 900,
+    /// City Tram Service.
+    CityTram = 901,
+    /// Local Tram Service. Examples: Munich (DE), Brussels (BE), Croydon (GB).
+    LocalTram = 902,
+    /// Regional Tram Service.
+    RegionalTram = 903,
+    /// Sightseeing Tram Service. Example: Blackpool Seafront (GB).
+    SightseeingTram = 904,
+    /// Shuttle Tram Service.
+    ShuttleTram = 905,
+    /// All Tram Services.
+    OtherTram = 906,
+
+    /// Water Transport Service.
+    WaterTransport = 1000,
+    /// Air Service.
+    Air = 1100,
+    /// Ferry Service.
+    Ferry = 1200,
+
+    /// Aerial Lift Service. Examples: Telefèric de Montjuïc (ES), Saleve (CH), Roosevelt Island Tramway (US).
+    AerialLift = 1300,
+    /// Telecabin Service.
+    Telecabin = 1301,
+    /// Cable Car Service.
+    CableCar = 1302,
+    /// Elevator Service.
+    Elevator = 1303,
+    /// Chair Lift Service.
+    ChairLift = 1304,
+    /// Drag Lift Service.
+    DragLift = 1305,
+    /// Small Telecabin Service.
+    SmallTelecabin = 1306,
+    /// All Telecabin Services.
+    OtherTelecabin = 1307,
+
+    // Funicular Service
+    /// Funicular Service. Example: Rigiblick (Zürich, CH).
+    Funicular = 1400,
+
+    /// Taxi Service.
+    Taxi = 1500,
+    /// Communal Taxi Service. Examples: Marshrutka (RU), dolmuş (TR).
+    CommunalTaxi = 1501,
+    /// Water Taxi Service.
+    WaterTaxi = 1502,
+    /// Rail Taxi Service.
+    RailTaxi = 1503,
+    /// Bike Taxi Service.
+    BikeTaxi = 1504,
+    /// Licensed Taxi Service.
+    LicensedTaxi = 1505,
+    /// Private Hire Service Vehicle.
+    PrivateHireServiceVehicle = 1506,
+    /// All Taxi Services.
+    OtherTaxi = 1507,
+
+    /// Miscellaneous Service.
+    MiscellaneousService = 1700,
+    /// Horse-drawn Carriage.
+    HorseDrawnCarriage = 1702,
+}
+
 /// Describes the kind of [Route]. See <https://gtfs.org/reference/static/#routestxt> `route_type`
 ///
-/// -ome route types are extended GTFS (<https://developers.google.com/transit/gtfs/reference/extended-route-types)>
+/// Some route types are extended GTFS (<https://developers.google.com/transit/gtfs/reference/extended-route-types)>
 #[derive(Debug, Default, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum RouteType {
     /// Tram, Streetcar, Light rail. Any light rail or street level system within a metropolitan area
     Tramway,
-    /// Tram, Streetcar, Light rail. Any light rail or street level system within a metropolitan area
+    /// Subway, Metro. Any underground rail system within a metropolitan area.
     Subway,
     /// Used for intercity or long-distance travel
     Rail,
@@ -106,14 +286,29 @@ pub enum RouteType {
     Gondola,
     /// Any rail system designed for steep inclines
     Funicular,
-    /// (extended) Used for intercity bus services
-    Coach,
-    /// (extended) Airplanes
-    Air,
-    /// (extended) Taxi, Cab
-    Taxi,
-    /// (extended) any other value
+    /// Google Transit extended route types <https://developers.google.com/transit/gtfs/reference/extended-route-types>
+    Extended(ExtendedRouteType),
+    /// Any other value
     Other(i16),
+}
+
+impl ExtendedRouteType {
+    /// Convert extended route types to standard route types if possible. All route types that can not be represented in standard route types at all are kept as-is.
+    /// This loses precision.
+    pub fn to_standard_route_type(&self) -> RouteType {
+        let int = *self as i16;
+        let hundreds = int / 100;
+        match hundreds {
+            1 => RouteType::Rail,
+            4 => RouteType::Subway,
+            2 | 7 | 8 => RouteType::Bus,
+            9 => RouteType::Tramway,
+            10 | 12 => RouteType::Ferry,
+            13 => RouteType::Gondola,
+            14 => RouteType::Funicular,
+            _ => RouteType::Extended(*self),
+        }
+    }
 }
 
 impl<'de> Deserialize<'de> for RouteType {
@@ -122,20 +317,19 @@ impl<'de> Deserialize<'de> for RouteType {
         D: Deserializer<'de>,
     {
         let i = i16::deserialize(deserializer)?;
+        if let Ok(ert) = ExtendedRouteType::try_from(i) {
+            return Ok(RouteType::Extended(ert));
+        }
 
-        let hundreds = i / 100;
-        Ok(match (i, hundreds) {
-            (0, _) | (_, 9) => RouteType::Tramway,
-            (1, _) | (_, 4) => RouteType::Subway,
-            (2, _) | (_, 1) => RouteType::Rail,
-            (3, _) | (_, 7) | (_, 8) => RouteType::Bus,
-            (4, _) | (_, 10) | (_, 12) => RouteType::Ferry,
-            (5, _) => RouteType::CableCar,
-            (6, _) | (_, 13) => RouteType::Gondola,
-            (7, _) | (_, 14) => RouteType::Funicular,
-            (_, 2) => RouteType::Coach,
-            (_, 11) => RouteType::Air,
-            (_, 15) => RouteType::Taxi,
+        Ok(match i {
+            0 => RouteType::Tramway,
+            1 => RouteType::Subway,
+            2 => RouteType::Rail,
+            3 => RouteType::Bus,
+            4 => RouteType::Ferry,
+            5 => RouteType::CableCar,
+            6 => RouteType::Gondola,
+            7 => RouteType::Funicular,
             _ => RouteType::Other(i),
         })
     }
@@ -146,7 +340,6 @@ impl Serialize for RouteType {
     where
         S: Serializer,
     {
-        // Note: for extended route type, we might loose the initial precise route type
         serializer.serialize_i16(match self {
             RouteType::Tramway => 0,
             RouteType::Subway => 1,
@@ -156,9 +349,7 @@ impl Serialize for RouteType {
             RouteType::CableCar => 5,
             RouteType::Gondola => 6,
             RouteType::Funicular => 7,
-            RouteType::Coach => 200,
-            RouteType::Air => 1100,
-            RouteType::Taxi => 1500,
+            RouteType::Extended(ert) => *ert as i16,
             RouteType::Other(i) => *i,
         })
     }


### PR DESCRIPTION
Fixes https://github.com/rust-transit/gtfs-structure/issues/110