### PR TITLE
making the id of the from_stop_id available in pathways.

### DIFF
--- a/src/gtfs.rs
+++ b/src/gtfs.rs
@@ -276,13 +276,20 @@ fn to_stop_map(
     }
 
     for pathway in raw_pathways {
+        
         stop_map.get(&pathway.to_stop_id).ok_or_else(|| {
             let stop_id = &pathway.to_stop_id;
             Error::ReferenceError(format!("'{stop_id}' in pathways.txt"))
         })?;
+        
+        let from_stop_id = pathway.from_stop_id.clone();
         stop_map
             .entry(pathway.from_stop_id.clone())
-            .and_modify(|stop| stop.pathways.push(Pathway::from(pathway)));
+            .and_modify(|stop| {
+                let mut pathway = Pathway::from(pathway);
+                pathway.from_stop_id = from_stop_id;
+                stop.pathways.push(pathway);
+            });
     }
 
     let res = stop_map

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -1024,6 +1024,8 @@ pub struct Pathway {
     pub signposted_as: Option<String>,
     /// Same than the signposted_as field, but when the pathways is used backward
     pub reversed_signposted_as: Option<String>,
+    /// the stop_id of the origin of the pathway
+    pub from_stop_id: String
 }
 
 impl Id for Pathway {
@@ -1053,6 +1055,7 @@ impl From<RawPathway> for Pathway {
             signposted_as: raw.signposted_as,
             stair_count: raw.stair_count,
             traversal_time: raw.traversal_time,
+            from_stop_id: raw.from_stop_id,
         }
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -229,6 +229,7 @@ fn read_pathways() {
     let pathways = &gtfs.get_stop("stop1").unwrap().pathways;
 
     assert_eq!(1, pathways.len());
+    assert_eq!("stop1",pathways[0].from_stop_id);
     assert_eq!("stop3", pathways[0].to_stop_id);
     assert_eq!(PathwayMode::Walkway, pathways[0].mode);
     assert_eq!(


### PR DESCRIPTION
Currently, the Pathways struct doesnt contain the field from_stop_id, although this field in read in the raw version. I believe the presence of this field can enable better validation of the pathways network, and ultitmately help in enabling better routing for mobility restricted users.